### PR TITLE
Using a pickled function object

### DIFF
--- a/docs/gallery/autogen/how_to.py
+++ b/docs/gallery/autogen/how_to.py
@@ -280,10 +280,48 @@ print("scaled_structures: ")
 for key, value in result["scaled_structures"].items():
     print(key, value)
 
+
+######################################################################
+# What if my calculation fails?
+# --------------------------------
+#
+# The `PythonJobParser` can return specialized exit codes when different
+# kinds of errors occur during the calculation:
+#
+# - ``ERROR_READING_OUTPUT_FILE`` (310):
+#     The retrieved output file (e.g., `results.pickle`) could not be opened or read.
+#
+# - ``ERROR_INVALID_OUTPUT`` (320):
+#     The output file is corrupt or contains unexpected/invalid data structures.
+#
+# - ``ERROR_RESULT_OUTPUT_MISMATCH`` (321):
+#     The number of actual results does not match the number/structure of expected outputs.
+#
+# - ``ERROR_IMPORT_CLOUDPICKLE_FAILED`` (322):
+#     The script on the remote machine failed to import `cloudpickle`.
+#     The script writes ``error.json`` describing the ImportError.
+#
+# - ``ERROR_UNPICKLE_INPUTS_FAILED`` (323):
+#     The script failed to unpickle the input data (e.g., `inputs.pickle`).
+#
+# - ``ERROR_UNPICKLE_FUNCTION_FAILED`` (324):
+#     The script failed to load the pickled function (e.g., `function.pkl`).
+#
+# - ``ERROR_FUNCTION_EXECUTION_FAILED`` (325):
+#     An exception was raised during the function call.
+#
+# - ``ERROR_PICKLE_RESULTS_FAILED`` (326):
+#     The script failed to pickle (serialize) the final results.
+#
+# - ``ERROR_SCRIPT_FAILED`` (327):
+#     A catch-all exit code if none of the above match. Indicates an unknown/unrecognized error.
+#
+
+
 ######################################################################
 # Exit Code
 # --------------
-#
+# Users can define custom exit codes to indicate the status of the task.
 #
 # When the function returns a dictionary with an `exit_code` key, the system
 # automatically parses and uses this code to indicate the task's status. In

--- a/src/aiida_pythonjob/calculations/utils.py
+++ b/src/aiida_pythonjob/calculations/utils.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+
+def generate_script_py(
+    pickled_function: bytes | None, source_code: str | None, function_name: str = "user_function"
+) -> str:
+    """
+    Generate the script.py content as a single string with robust exception handling.
+
+    :param pickled_function: Serialized function bytes if running in pickled mode, else None.
+    :param source_code: Raw Python source code if running in source-code mode, else None.
+    :param function_name: The name of the function to call when running source code mode.
+    :return: A string representing the entire content of script.py.
+    """
+    # We build a list of lines, then join them with '\n' at the end
+    script_lines = [
+        "import sys",
+        "import json",
+        "import traceback",
+        "",
+        "def write_error_file(error_type, exc, traceback_str):",
+        "    # Write an error file to disk so the parser can detect the error",
+        "    error_data = {",
+        "        'error_type': error_type,",
+        "        'exception_message': str(exc),",
+        "        'traceback': traceback_str,",
+        "    }",
+        "    with open('_error.json', 'w') as f:",
+        "        json.dump(error_data, f, indent=2)",
+        "",
+        "def main():",
+        "    # 1) Attempt to import cloudpickle",
+        "    try:",
+        "        import cloudpickle as pickle",
+        "    except ImportError as e:",
+        "        write_error_file('IMPORT_CLOUDPICKLE_FAILED', e, traceback.format_exc())",
+        "        sys.exit(1)",
+        "",
+        "    # 2) Attempt to unpickle the inputs",
+        "    try:",
+        "        with open('inputs.pickle', 'rb') as handle:",
+        "            inputs = pickle.load(handle)",
+        "    except Exception as e:",
+        "        write_error_file('UNPICKLE_INPUTS_FAILED', e, traceback.format_exc())",
+        "        sys.exit(1)",
+        "",
+    ]
+
+    if pickled_function:
+        # Mode 1: pickled function
+        script_lines += [
+            "    # 3) Attempt to unpickle the function",
+            "    try:",
+            "        with open('function.pkl', 'rb') as f:",
+            "            user_function = pickle.load(f)",
+            "    except Exception as e:",
+            "        write_error_file('UNPICKLE_FUNCTION_FAILED', e, traceback.format_exc())",
+            "        sys.exit(1)",
+            "",
+            "    # 4) Attempt to run the function",
+            "    try:",
+            "        result = user_function(**inputs)",
+            "    except Exception as e:",
+            "        write_error_file('FUNCTION_EXECUTION_FAILED', e, traceback.format_exc())",
+            "        sys.exit(1)",
+        ]
+    elif source_code:
+        # Mode 2: raw source code
+        # Indent each line of source_code by 4 spaces to keep correct indentation
+        source_lines = [f"    {line}" for line in source_code.split("\n")]
+        script_lines += [
+            "    # 3) Define the function from raw source code",
+            *source_lines,
+            "",
+            "    # 4) Attempt to run the function",
+            "    try:",
+            f"        result = {function_name}(**inputs)",
+            "    except Exception as e:",
+            "        write_error_file('FUNCTION_EXECUTION_FAILED', e, traceback.format_exc())",
+            "        sys.exit(1)",
+        ]
+    else:
+        raise ValueError("You must provide exactly one of 'source_code' or 'pickled_function'.")
+
+    # 5) Attempt to pickle (save) the result
+    script_lines += [
+        "",
+        "    # 5) Attempt to pickle the result",
+        "    try:",
+        "        with open('results.pickle', 'wb') as handle:",
+        "            pickle.dump(result, handle)",
+        "    except Exception as e:",
+        "        write_error_file('PICKLE_RESULTS_FAILED', e, traceback.format_exc())",
+        "        sys.exit(1)",
+        "",
+        "    # If we've made it this far, everything succeeded. Write an empty _error.json",
+        "    # so the parser can always read _error.json (if it's empty, no error).",
+        "    with open('_error.json', 'w') as f:",
+        "        json.dump({}, f, indent=2)",
+        "",
+        "if __name__ == '__main__':",
+        "    main()",
+        "",
+    ]
+
+    # Join lines with newline
+    script_content = "\n".join(script_lines)
+    return script_content

--- a/src/aiida_pythonjob/data/pickled_data.py
+++ b/src/aiida_pythonjob/data/pickled_data.py
@@ -58,6 +58,14 @@ class PickledData(orm.Data):
                 "Please ensure that the correct environment and cloudpickle version are being used."
             ) from e
 
+    def get_serialized_value(self):
+        """Return the serialized value stored in the repository.
+
+        :return: The serialized value.
+        """
+        with self.base.repository.open(self.FILENAME, mode="rb") as f:
+            return f.read()
+
     def set_value(self, value):
         """Set the contents of this node by pickling the provided value.
 

--- a/src/aiida_pythonjob/launch.py
+++ b/src/aiida_pythonjob/launch.py
@@ -53,32 +53,18 @@ def prepare_pythonjob_inputs(
     if code is None:
         command_info = command_info or {}
         code = get_or_create_code(computer=computer, **command_info)
-    # get the source code of the function
-    function_name = function_data["name"]
-    if function_data.get("is_pickle", False):
-        function_source_code = (
-            function_data["import_statements"] + "\n" + function_data["source_code_without_decorator"]
-        )
-    else:
-        function_source_code = f"from {function_data['module']} import {function_name}"
-
     # serialize the kwargs into AiiDA Data
     function_inputs = function_inputs or {}
     function_inputs = serialize_to_aiida_nodes(function_inputs)
-    # transfer the args to kwargs
+    function_data["outputs"] = function_outputs or [{"name": "result"}]
     inputs = {
-        "process_label": process_label or "PythonJob<{}>".format(function_name),
-        "function_data": orm.Dict(
-            {
-                "source_code": function_source_code,
-                "name": function_name,
-                "outputs": function_outputs or [],
-            }
-        ),
+        "function_data": function_data,
         "code": code,
         "function_inputs": function_inputs,
         "upload_files": new_upload_files,
         "metadata": metadata or {},
         **kwargs,
     }
+    if process_label:
+        inputs[process_label] = process_label
     return inputs

--- a/src/aiida_pythonjob/parsers/pythonjob.py
+++ b/src/aiida_pythonjob/parsers/pythonjob.py
@@ -1,84 +1,122 @@
 """Parser for an `PythonJob` job."""
 
+import json
+
 from aiida.engine import ExitCode
 from aiida.parsers.parser import Parser
+
+# Map error_type from script.py to exit code label
+ERROR_TYPE_TO_EXIT_CODE = {
+    "IMPORT_CLOUDPICKLE_FAILED": "ERROR_IMPORT_CLOUDPICKLE_FAILED",
+    "UNPICKLE_INPUTS_FAILED": "ERROR_UNPICKLE_INPUTS_FAILED",
+    "UNPICKLE_FUNCTION_FAILED": "ERROR_UNPICKLE_FUNCTION_FAILED",
+    "FUNCTION_EXECUTION_FAILED": "ERROR_FUNCTION_EXECUTION_FAILED",
+    "PICKLE_RESULTS_FAILED": "ERROR_PICKLE_RESULTS_FAILED",
+}
 
 
 class PythonJobParser(Parser):
     """Parser for an `PythonJob` job."""
 
     def parse(self, **kwargs):
-        """Parse the contents of the output files stored in the `retrieved` output node.
-
-        The function_outputs could be a namespce, e.g.,
-        function_outputs=[
-            {"identifier": "namespace", "name": "add_multiply"},
-            {"name": "add_multiply.add"},
-            {"name": "add_multiply.multiply"},
-            {"name": "minus"},
-        ]
-        """
         import pickle
 
-        function_outputs = self.node.inputs.function_data.get_dict()["outputs"]
-        if len(function_outputs) == 0:
+        # Read function_outputs specification
+        if "outputs" in self.node.inputs.function_data:
+            function_outputs = self.node.inputs.function_data.outputs.get_list()
+        else:
             function_outputs = [{"name": "result"}]
         self.output_list = function_outputs
-        # first we remove nested outputs, e.g., "add_multiply.add"
+
+        # If nested outputs like "add_multiply.add", keep only top-level
         top_level_output_list = [output for output in self.output_list if "." not in output["name"]]
+
+        # 1) Read _error.json
+        error_data = {}
+        try:
+            with self.retrieved.base.repository.open("_error.json", "r") as ef:
+                error_data = json.load(ef)
+        except OSError:
+            # No _error.json file found
+            pass
+        except json.JSONDecodeError as exc:
+            self.logger.error(f"Error reading _error.json: {exc}")
+            return self.exit_codes.ERROR_INVALID_OUTPUT  # or a different exit code
+
+        # If error_data is non-empty, we have an error from the script
+        if error_data:
+            error_type = error_data.get("error_type", "UNKNOWN_ERROR")
+            exception_message = error_data.get("exception_message", "")
+            traceback_str = error_data.get("traceback", "")
+
+            # Default to a generic code if we can't match a known error_type
+            exit_code_label = ERROR_TYPE_TO_EXIT_CODE.get(error_type, "ERROR_SCRIPT_FAILED")
+
+            # Use `.format()` to inject the exception and traceback
+            return self.exit_codes[exit_code_label].format(exception=exception_message, traceback=traceback_str)
+        # 2) If we reach here, _error.json exists but is empty or doesn't exist at all -> no error recorded
+        #    Proceed with parsing results.pickle
         try:
             with self.retrieved.base.repository.open("results.pickle", "rb") as handle:
                 results = pickle.load(handle)
+
                 if isinstance(results, tuple):
                     if len(top_level_output_list) != len(results):
                         return self.exit_codes.ERROR_RESULT_OUTPUT_MISMATCH
                     for i in range(len(top_level_output_list)):
                         top_level_output_list[i]["value"] = self.serialize_output(results[i], top_level_output_list[i])
+
                 elif isinstance(results, dict):
-                    # pop the exit code if it exists
+                    # pop the exit code if it exists inside the dictionary
                     exit_code = results.pop("exit_code", None)
                     if exit_code:
+                        # If there's an exit_code, handle it (dict or int)
                         if isinstance(exit_code, dict):
                             exit_code = ExitCode(exit_code["status"], exit_code["message"])
                         elif isinstance(exit_code, int):
                             exit_code = ExitCode(exit_code)
                         if exit_code.status != 0:
                             return exit_code
+
                     if len(top_level_output_list) == 1:
-                        # if output name in results, use it
+                        # If output name in results, use it
                         if top_level_output_list[0]["name"] in results:
                             top_level_output_list[0]["value"] = self.serialize_output(
                                 results.pop(top_level_output_list[0]["name"]),
                                 top_level_output_list[0],
                             )
-                            # if there are any remaining results, raise an warning
+                            # If there are any extra keys in `results`, log a warning
                             if len(results) > 0:
                                 self.logger.warning(
                                     f"Found extra results that are not included in the output: {results.keys()}"
                                 )
-                        # otherwise, we assume the results is the output
                         else:
+                            # Otherwise assume the entire dict is the single output
                             top_level_output_list[0]["value"] = self.serialize_output(results, top_level_output_list[0])
                     elif len(top_level_output_list) > 1:
+                        # Match each top-level output by name
                         for output in top_level_output_list:
                             if output["name"] not in results:
                                 if output.get("required", True):
                                     return self.exit_codes.ERROR_MISSING_OUTPUT
                             else:
                                 output["value"] = self.serialize_output(results.pop(output["name"]), output)
-                        # if there are any remaining results, raise an warning
+                        # Any remaining results are unaccounted for -> log a warning
                         if len(results) > 0:
                             self.logger.warning(
                                 f"Found extra results that are not included in the output: {results.keys()}"
                             )
 
                 elif len(top_level_output_list) == 1:
-                    # otherwise it returns a single value, we assume the results is the output
+                    # Single top-level output, single result
                     top_level_output_list[0]["value"] = self.serialize_output(results, top_level_output_list[0])
                 else:
                     return self.exit_codes.ERROR_RESULT_OUTPUT_MISMATCH
+
+                # Store the outputs
                 for output in top_level_output_list:
                     self.out(output["name"], output["value"])
+
         except OSError:
             return self.exit_codes.ERROR_READING_OUTPUT_FILE
         except ValueError as exception:
@@ -86,7 +124,7 @@ class PythonJobParser(Parser):
             return self.exit_codes.ERROR_INVALID_OUTPUT
 
     def find_output(self, name):
-        """Find the output with the given name."""
+        """Find the output spec with the given name."""
         for output in self.output_list:
             if output["name"] == name:
                 return output
@@ -109,6 +147,7 @@ class PythonJobParser(Parser):
                         serialized_result[key] = general_serializer(value)
                 return serialized_result
             else:
-                self.exit_codes.ERROR_INVALID_OUTPUT
+                self.logger.error(f"Expected a dict for namespace '{name}', got {type(result)}.")
+                return self.exit_codes.ERROR_INVALID_OUTPUT
         else:
             return general_serializer(result)

--- a/tests/test_pythonjob.py
+++ b/tests/test_pythonjob.py
@@ -19,7 +19,7 @@ def test_validate_inputs():
     with pytest.raises(ValueError, match="Only one of function or function_data should be provided"):
         prepare_pythonjob_inputs(
             function=add,
-            function_data={"module": "math", "name": "sqrt", "is_pickle": False},
+            function_data={"module_path": "math", "name": "sqrt", "is_pickle": False},
         )
 
 
@@ -53,7 +53,6 @@ def test_function_custom_outputs(fixture_localhost):
             {"name": "diff"},
         ],
     )
-    inputs.pop("process_label")
     result, node = run_get_node(PythonJob, **inputs)
 
     assert result["sum"].value == 3
@@ -295,3 +294,18 @@ def test_exit_code(fixture_localhost):
     result, node = run_get_node(PythonJob, inputs=inputs)
     assert node.exit_status == 410
     assert node.exit_message == "Some elements are negative"
+
+
+def test_local_function(fixture_localhost):
+    def multily(x, y):
+        return x * y
+
+    def add(x, y):
+        return x + multily(x, y)
+
+    inputs = prepare_pythonjob_inputs(
+        add,
+        function_inputs={"x": 2, "y": 3},
+    )
+    result, node = run_get_node(PythonJob, **inputs)
+    assert result["result"].value == 8

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,12 @@ def test_build_function_data():
     from math import sqrt
 
     function_data = build_function_data(sqrt)
-    assert function_data == {"module": "math", "name": "sqrt", "is_pickle": False}
+    assert function_data == {
+        "name": "sqrt",
+        "mode": "use_module_path",
+        "module_path": "math",
+        "source_code": "from math import sqrt",
+    }
     #
     try:
         function_data = build_function_data(1)


### PR DESCRIPTION
PythonJob supports two modes of running the function on the remote machine:
- Using a pickled function object (default)
- Using raw Python source code

Use try-except blocks around each operation in the `script.py` that might fail, and record the error in a file, and the parser can process. In particular, we want to capture:

- Failed to import cloudpickle.
- Failed to unpickle the inputs.
- Failed to unpickle the function.
- The function execution itself fails.
- Failed to pickle the results.