### PR TITLE
add `register_pickle_by_value`

### DIFF
--- a/docs/gallery/autogen/how_to.py
+++ b/docs/gallery/autogen/how_to.py
@@ -347,6 +347,33 @@ result, node = run_get_node(PythonJob, inputs=inputs)
 print("exit_status:", node.exit_status)
 print("exit_message:", node.exit_message)
 
+######################################################################
+# Using `register_pickle_by_value`
+# --------------------------------
+#
+# If the function is defined inside an external module that is **not installed** on
+# the remote computer, this can cause import errors during execution.
+#
+# **Solution:**
+# By enabling `register_pickle_by_value=True`, the function is serialized **by value**
+# instead of being referenced by its module path. This embeds the function unpickled
+# even if the original module is unavailable on the remote computer.
+#
+# **Example:**
+#
+# .. code-block:: python
+#
+#     inputs = prepare_pythonjob_inputs(
+#         my_function,
+#         function_inputs={"x": 1, "y": 2},
+#         computer="localhost",
+#         register_pickle_by_value=True,  # Ensures function is embedded
+#     )
+#
+# **Important Considerations:**: If the function **contains import statements**,
+# the imported modules **must still be installed** on the remote computer.
+#
+
 
 ######################################################################
 # Define your data serializer and deserializer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = [
+  "hatch",
+]
 pre-commit = [
   'pre-commit~=3.5',
 ]

--- a/src/aiida_pythonjob/launch.py
+++ b/src/aiida_pythonjob/launch.py
@@ -22,6 +22,7 @@ def prepare_pythonjob_inputs(
     function_data: dict | None = None,
     deserializers: dict | None = None,
     serializers: dict | None = None,
+    register_pickle_by_value: bool = False,
     **kwargs: Any,
 ) -> Dict[str, Any]:
     """Prepare the inputs for PythonJob"""
@@ -33,7 +34,7 @@ def prepare_pythonjob_inputs(
         raise ValueError("Only one of function or function_data should be provided")
     # if function is a function, inspect it and get the source code
     if function is not None and inspect.isfunction(function):
-        function_data = build_function_data(function)
+        function_data = build_function_data(function, register_pickle_by_value=register_pickle_by_value)
     new_upload_files = {}
     # change the string in the upload files to SingleFileData, or FolderData
     for key, source in upload_files.items():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,17 +1,46 @@
+import pytest
 from aiida_pythonjob.utils import build_function_data
 
 
 def test_build_function_data():
-    from math import sqrt
+    """Test the build_function_data function behavior."""
 
-    function_data = build_function_data(sqrt)
-    assert function_data == {
-        "name": "sqrt",
-        "mode": "use_module_path",
-        "source_code": "from math import sqrt",
-    }
-    #
-    try:
-        function_data = build_function_data(1)
-    except Exception as e:
-        assert str(e) == "Provided object is not a callable function or class."
+    with pytest.raises(TypeError, match="Provided object is not a callable function or class."):
+        build_function_data(1)
+
+    function_data = build_function_data(build_function_data)
+    assert function_data["name"] == "build_function_data"
+    assert "source_code" in function_data
+    assert "pickled_function" in function_data
+    node = function_data["pickled_function"]
+    with node.base.repository.open(node.FILENAME, mode="rb") as f:
+        text = f.read()
+        assert b"cloudpickle" not in text
+
+    function_data = build_function_data(build_function_data, register_pickle_by_value=True)
+    assert function_data["name"] == "build_function_data"
+    assert "source_code" in function_data
+    assert "pickled_function" in function_data
+    node = function_data["pickled_function"]
+    with node.base.repository.open(node.FILENAME, mode="rb") as f:
+        text = f.read()
+        assert b"cloudpickle" in text
+
+    def local_function(x, y):
+        return x + y
+
+    function_data = build_function_data(local_function)
+    assert function_data["name"] == "local_function"
+    assert "source_code" in function_data
+    assert function_data["mode"] == "use_pickled_function"
+
+    def outer_function():
+        def nested_function(x, y):
+            return x + y
+
+        return nested_function
+
+    nested_func = outer_function()
+    function_data = build_function_data(nested_func)
+    assert function_data["name"] == "nested_function"
+    assert function_data["mode"] == "use_pickled_function"


### PR DESCRIPTION

By enabling register_pickle_by_value=True, the function is serialized by value instead of being referenced by its module path. This embeds the function unpickled even if the original module is unavailable on the remote computer.

Note: If the function contains import statements, the imported modules must still be installed on the remote computer.