### PR TITLE
Add traceback in serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/source/autogen/
+docs/source/sg_execution_times.rst
 
 # PyBuilder
 .pybuilder/

--- a/docs/gallery/autogen/pyfunction.py
+++ b/docs/gallery/autogen/pyfunction.py
@@ -1,0 +1,191 @@
+"""
+PyFunction
+===============
+
+"""
+
+######################################################################
+# Default outputs
+# --------------
+#
+# The default output of the function is `result`. The `pyfunction` task
+# will store the result as one node in the database with the key `result`.
+#
+from aiida import load_profile
+from aiida.engine import run_get_node
+from aiida_pythonjob import pyfunction
+
+load_profile()
+
+
+@pyfunction()
+def add(x, y):
+    return x + y
+
+
+result, node = run_get_node(add, x=1, y=2)
+print("result: ", result)
+
+######################################################################
+# Custom outputs
+# --------------
+# If the function return a dictionary with fixed number of keys, and you
+# want to store the values as separate outputs, you can specify the `function_outputs` parameter.
+# For a dynamic number of outputs, you can use the namespace output, which is explained later.
+#
+
+
+@pyfunction(outputs=[{"name": "sum"}, {"name": "diff"}])
+def add(x, y):
+    return {"sum": x + y, "diff": x - y}
+
+
+result, node = run_get_node(add, x=1, y=2)
+
+print("result: ")
+print("sum: ", result["sum"])
+print("diff: ", result["diff"])
+
+######################################################################
+# Namespace Output
+# --------------
+#
+# The `pyfunction` allows users to define namespace outputs. A namespace output
+# is a dictionary with keys and values returned by a function. Each value in
+# this dictionary will be serialized to AiiDA data, and the key-value pair
+# will be stored in the database.
+#
+# Why Use Namespace Outputs?
+#
+# - **Dynamic and Flexible**: The keys and values in the namespace output are not fixed and can change based on the task's execution. # noqa
+# - **Querying**: The data in the namespace output is stored as an AiiDA data node, allowing for easy querying and retrieval. # noqa
+# - **Data Provenance**: When the data is used as input for subsequent tasks, the origin of data is tracked.
+#
+# For example: Consider a molecule adsorption calculation where the namespace
+# output stores the surface slabs of the molecule adsorbed on different surface
+# sites. The number of surface slabs can vary depending on the surface. These
+# output surface slabs can be utilized as input to the next task to calculate the energy.
+
+from ase import Atoms  # noqa: E402
+from ase.build import bulk  # noqa: E402
+
+
+@pyfunction(outputs=[{"name": "scaled_structures", "identifier": "namespace"}])
+def generate_structures(structure: Atoms, factor_lst: list) -> dict:
+    """Scale the structure by the given factor_lst."""
+    scaled_structures = {}
+    for i in range(len(factor_lst)):
+        atoms = structure.copy()
+        atoms.set_cell(atoms.cell * factor_lst[i], scale_atoms=True)
+        scaled_structures[f"s_{i}"] = atoms
+    return {"scaled_structures": scaled_structures}
+
+
+result, node = run_get_node(generate_structures, structure=bulk("Al"), factor_lst=[0.95, 1.0, 1.05])
+print("scaled_structures: ")
+for key, value in result["scaled_structures"].items():
+    print(key, value)
+
+
+######################################################################
+# Exit Code
+# --------------
+# Users can define custom exit codes to indicate the status of the task.
+#
+# When the function returns a dictionary with an `exit_code` key, the system
+# automatically parses and uses this code to indicate the task's status. In
+# the case of an error, the non-zero `exit_code` value helps identify the specific problem.
+#
+#
+
+
+@pyfunction()
+def add(x, y):
+    sum = x + y
+    if sum < 0:
+        exit_code = {"status": 410, "message": "Some elements are negative"}
+        return {"sum": sum, "exit_code": exit_code}
+    return {"sum": sum}
+
+
+result, node = run_get_node(add, x=1, y=-2)
+print("exit_status:", node.exit_status)
+print("exit_message:", node.exit_message)
+
+
+######################################################################
+# Define your data serializer and deserializer
+# --------------
+#
+# PythonJob search data serializer from the `aiida.data` entry point by the
+# module name and class name (e.g., `ase.atoms.Atoms`).
+#
+# In order to let the PythonJob find the serializer, you must register the
+# AiiDA data with the following format:
+#
+# .. code-block:: ini
+#
+#    [project.entry-points."aiida.data"]
+#    abc.ase.atoms.Atoms = "abc.xyz:MyAtomsData"
+#
+# This will register a data serializer for `ase.atoms.Atoms` data. `abc` is
+# the plugin name, the module name is `xyz`, and the AiiDA data class name is
+# `AtomsData`. Learn how to create an AiiDA data class `here <https://aiida.readthedocs.io/projects/aiida-core/en/stable/topics/data_types.html#adding-support-for-custom-data-types>`_.
+#
+# *Avoid duplicate data serializer*: If you have multiple plugins that
+# register the same data serializer, the PythonJob will raise an error.
+# You can avoid this by selecting the plugin that you want to use in the configuration file.
+#
+#
+# .. code-block:: json
+#
+#    {
+#        "serializers": {
+#            "ase.atoms.Atoms": "abc.ase.atoms.AtomsData" # use the full path to the serializer
+#        }
+#    }
+#
+# Save the configuration file as `pythonjob.json` in the aiida configuration
+# directory (by default, `~/.aiida` directory).
+#
+# If you want to pass AiiDA Data node as input, and the node does not have a `value` attribute,
+# then one must provide a deserializer for it.
+#
+
+from aiida import orm  # noqa: E402
+
+
+@pyfunction()
+def make_supercell(structure, n=2):
+    return structure * [n, n, n]
+
+
+structure = orm.StructureData(cell=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+structure.append_atom(position=(0.0, 0.0, 0.0), symbols="Li")
+
+result, node = run_get_node(
+    make_supercell,
+    structure=structure,
+    deserializers={
+        "aiida.orm.nodes.data.structure.StructureData": "aiida_pythonjob.data.deserializer.structure_data_to_atoms"
+    },
+)
+print("result: ", result)
+
+######################################################################
+# One can also set the deserializer in the configuration file.
+#
+#
+# .. code-block:: json
+#
+#    {
+#        "serializers": {
+#            "ase.atoms.Atoms": "abc.ase.atoms.Atoms"
+#        },
+#        "deserializers": {
+#            "aiida.orm.nodes.data.structure.StructureData": "aiida_pythonjob.data.deserializer.structure_data_to_pymatgen" # noqa
+#        }
+#    }
+#
+# The `orm.List`, `orm.Dict`and `orm.StructureData` data types already have built-in deserializers.
+#

--- a/docs/gallery/autogen/pythonjob.py
+++ b/docs/gallery/autogen/pythonjob.py
@@ -1,5 +1,5 @@
 """
-How to guides
+PythonJob
 ===============
 
 """

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,17 +1,45 @@
+AiiDA PythonJob & PyFunction
+============================
 
-AiiDA PythonJob
-===========================================
+`PythonJob` and `pyfunction` enable users to run Python functions—either locally or remotely—with automatic serialization, provenance tracking, and workflow integration.
 
-
-`PythonJob` allows users to run Python functions on a remote computer. It is designed to enable users from non-AiiDA communities to run their Python functions remotely and construct workflows with checkpoints, maintaining all data provenance. For instance, users can use ASE's calculator to run a DFT calculation on a remote computer directly.
+These tools are designed to simplify the experience for users not familiar with AiiDA's internal types, allowing them to write pure Python functions while still benefiting from AiiDA's powerful infrastructure.
 
 **Key Features**
 
-1. **Remote Execution**: Seamlessly run Python functions on a remote computer.
-2. **User-Friendly**: Designed for users who are not familiar with AiiDA, simplifying the process of remote execution.
-3. **Workflow Management**: Construct workflows using WorkGraph with checkpoints, ensuring that intermediate states and results are preserved.
-4. **Data Provenance**: Maintain comprehensive data provenance, tracking the full history and transformations of data.
+1. **Remote Execution with PythonJob**  
+   Seamlessly run Python functions on a remote computer via `PythonJob`. A working directory is automatically created for the job, allowing full support for:
+   
+   - File upload and retrieval
+   - Parent/remote folders
+   - Integration with external codes (e.g. ASE + DFT engines)
 
+2. **Local Execution with PyFunction**  
+   Use `@pyfunction` to run pure Python functions locally. All inputs and outputs are automatically serialized/deserialized, enabling users to work with native Python types.  
+   This decorator is ideal for functions that are:
+   
+   .. note::
+      `pyfunction` does **not** create a dedicated working directory. It executes in the current local Python environment.  
+      File I/O or relative path access should be avoided unless explicitly handled.
+
+3. **User-Friendly Interface**  
+   Designed for users unfamiliar with AiiDA’s internal `Data` classes. The decorators handle all conversion and provenance tracking behind the scenes.
+
+4. **Workflow Management with Checkpoints**  
+   Combine `pyfunction` and `pythonjob` in `WorkGraph` workflows to build robust, restartable workflows with full checkpoint support.
+
+5. **Full Data Provenance**  
+   All inputs, outputs, and intermediate results are stored in the AiiDA provenance graph, ensuring reproducibility and traceability.
+
+**When to Use What**
+
++----------------+--------------------+---------------------+------------------+---------------------------------------------+
+| Decorator      | Execution          | Input/Output Types  | AiiDA Provenance | Recommended Use Case                        |
++================+====================+=====================+==================+=============================================+
+| ``@pyfunction``| Local              | Python native       | ✅ Yes           | Pure functions                              |
++----------------+--------------------+---------------------+------------------+---------------------------------------------+
+| ``@pythonjob`` | Remote             | Python native       | ✅ Yes           | Remote jobs with file handling              |
++----------------+--------------------+---------------------+------------------+---------------------------------------------+
 
 .. toctree::
    :maxdepth: 1
@@ -19,8 +47,6 @@ AiiDA PythonJob
    :hidden:
 
    installation
-   autogen/how_to
+   autogen/pythonjob
+   autogen/pyfunction
    tutorial/index
-
-
-

--- a/src/aiida_pythonjob/__init__.py
+++ b/src/aiida_pythonjob/__init__.py
@@ -3,11 +3,13 @@
 __version__ = "0.1.8"
 
 from .calculations import PythonJob
+from .decorator import pyfunction
 from .launch import prepare_pythonjob_inputs
 from .parsers import PythonJobParser
 
 __all__ = (
     "PythonJob",
+    "pyfunction",
     "PickledData",
     "prepare_pythonjob_inputs",
     "PythonJobParser",

--- a/src/aiida_pythonjob/calculations/pyfunction.py
+++ b/src/aiida_pythonjob/calculations/pyfunction.py
@@ -122,7 +122,7 @@ class PyFunction(Process):
         return result
 
     @override
-    async def run(self) -> ExitCode | None:
+    def run(self) -> ExitCode | None:
         """Run the process."""
 
         from aiida_pythonjob.data.deserializer import deserialize_to_raw_python_data

--- a/src/aiida_pythonjob/calculations/pyfunction.py
+++ b/src/aiida_pythonjob/calculations/pyfunction.py
@@ -1,0 +1,260 @@
+"""Proess to run a Python function locally"""
+
+from __future__ import annotations
+
+import inspect
+import typing as t
+
+from aiida.common.lang import override
+from aiida.engine import Process, ProcessSpec
+from aiida.engine.processes.exit_code import ExitCode
+from aiida.orm import (
+    CalcFunctionNode,
+    Data,
+    Dict,
+    List,
+    Str,
+    to_aiida_type,
+)
+
+__all__ = ("PyFunction",)
+
+
+# The following code is modified from the aiida-core.engine.processes.functions module
+
+
+# TODO: because aiida-core cmds hardcode `CalcFunctionNode`, I hardcoded `CalcFunctionNode` here.
+# In principle, aiida-core should support subclassing
+class PyFunction(Process):
+    """"""
+
+    _node_class = CalcFunctionNode
+
+    def __init__(self, *args, **kwargs) -> None:
+        if kwargs.get("enable_persistence", False):
+            raise RuntimeError("Cannot persist a function process")
+        super().__init__(enable_persistence=False, *args, **kwargs)  # type: ignore[misc]
+        self._func = None
+
+    @property
+    def func(self) -> t.Callable[..., t.Any]:
+        if self._func is None:
+            self._func = self.inputs.function_data.pickled_function.value
+        return self._func
+
+    @classmethod
+    def define(cls, spec: ProcessSpec) -> None:  # type: ignore[override]
+        """Define the process specification, including its inputs, outputs and known exit codes."""
+        super().define(spec)
+        spec.input_namespace("function_data")
+        spec.input("function_data.name", valid_type=Str, serializer=to_aiida_type)
+        spec.input("function_data.source_code", valid_type=Str, serializer=to_aiida_type, required=False)
+        spec.input("function_data.outputs", valid_type=List, serializer=to_aiida_type, required=False)
+        spec.input("function_data.pickled_function", valid_type=Data, required=False)
+        spec.input("function_data.mode", valid_type=Str, serializer=to_aiida_type, required=False)
+        spec.input("process_label", valid_type=Str, serializer=to_aiida_type, required=False)
+        spec.input_namespace("function_inputs", valid_type=Data, required=False)
+        spec.input(
+            "deserializers",
+            valid_type=Dict,
+            default=None,
+            required=False,
+            serializer=to_aiida_type,
+            help="The deserializers to convert the input AiiDA data nodes to raw Python data.",
+        )
+        spec.input(
+            "serializers",
+            valid_type=Dict,
+            default=None,
+            required=False,
+            serializer=to_aiida_type,
+            help="The serializers to convert the raw Python data to AiiDA data nodes.",
+        )
+        spec.inputs.dynamic = True
+        spec.outputs.dynamic = True
+        spec.exit_code(
+            320,
+            "ERROR_INVALID_OUTPUT",
+            invalidates_cache=True,
+            message="The output file contains invalid output.",
+        )
+        spec.exit_code(
+            321,
+            "ERROR_RESULT_OUTPUT_MISMATCH",
+            invalidates_cache=True,
+            message="The number of results does not match the number of outputs.",
+        )
+
+    def get_function_name(self) -> str:
+        """Return the name of the function to run."""
+        if "name" in self.inputs.function_data:
+            name = self.inputs.function_data.name.value
+        else:
+            try:
+                name = self.inputs.function_data.pickled_function.value.__name__
+            except AttributeError:
+                # If a user doesn't specify name, fallback to something generic
+                name = "anonymous_function"
+        return name
+
+    def _build_process_label(self) -> str:
+        """Use the function name or an explicit label as the process label."""
+        if "process_label" in self.inputs:
+            return self.inputs.process_label.value
+        else:
+            name = self.get_function_name()
+            return f"{name}"
+
+    @override
+    def _setup_db_record(self) -> None:
+        """Set up the database record for the process."""
+        super()._setup_db_record()
+        self.node.store_source_info(self.func)
+
+    def execute(self) -> dict[str, t.Any] | None:
+        """Execute the process."""
+        result = super().execute()
+
+        # FunctionProcesses can return a single value as output, and not a dictionary, so we should also return that
+        if result and len(result) == 1 and self.SINGLE_OUTPUT_LINKNAME in result:
+            return result[self.SINGLE_OUTPUT_LINKNAME]
+
+        return result
+
+    @override
+    async def run(self) -> ExitCode | None:
+        """Run the process."""
+
+        from aiida_pythonjob.data.deserializer import deserialize_to_raw_python_data
+
+        # The following conditional is required for the caching to properly work. Even if the source node has a process
+        # state of `Finished` the cached process will still enter the running state. The process state will have then
+        # been overridden by the engine to `Running` so we cannot check that, but if the `exit_status` is anything other
+        # than `None`, it should mean this node was taken from the cache, so the process should not be rerun.
+        if self.node.exit_status is not None:
+            return ExitCode(self.node.exit_status, self.node.exit_message)
+
+        # Now the original functions arguments need to be reconstructed from the inputs to the process, as they were
+        # passed to the original function call. To do so, all positional parameters are popped from the inputs
+        # dictionary and added to the positional arguments list.
+        args = []
+        kwargs: dict[str, Data] = {}
+        inputs = dict(self.inputs.function_inputs or {})
+
+        for name, parameter in inspect.signature(self.func).parameters.items():
+            if parameter.kind in [parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD]:
+                if name in inputs:
+                    args.append(inputs.pop(name))
+            elif parameter.kind is parameter.VAR_POSITIONAL:
+                for key in [key for key in inputs.keys() if key.startswith(f"{name}_")]:
+                    args.append(inputs.pop(key))
+
+        # Any inputs that correspond to metadata ports were not part of the original function signature but were added
+        # by the process function decorator, so these have to be removed.
+        for key in [key for key, port in self.spec().inputs.items() if port.is_metadata]:
+            inputs.pop(key, None)
+
+        # The remaining inputs have to be keyword arguments.
+        kwargs.update(**inputs)
+        raw_args = [deserialize_to_raw_python_data(x) for x in args]
+        raw_kwargs = {k: deserialize_to_raw_python_data(v) for k, v in kwargs.items()}
+
+        results = self.func(*raw_args, **raw_kwargs)
+
+        # Read function_outputs specification
+        if "outputs" in self.inputs.function_data:
+            function_outputs = self.node.inputs.function_data.outputs.get_list()
+        else:
+            function_outputs = [{"name": "result"}]
+        self.output_list = function_outputs
+        # load custom serializers
+        if "serializers" in self.node.inputs and self.node.inputs.serializers:
+            serializers = self.node.inputs.serializers.get_dict()
+            # replace "__dot__" with "." in the keys
+            self.serializers = {k.replace("__dot__", "."): v for k, v in serializers.items()}
+        else:
+            self.serializers = None
+
+        # If nested outputs like "add_multiply.add", keep only top-level
+        top_level_output_list = [output for output in self.output_list if "." not in output["name"]]
+        if isinstance(results, tuple):
+            if len(top_level_output_list) != len(results):
+                return self.exit_codes.ERROR_RESULT_OUTPUT_MISMATCH
+            for i in range(len(top_level_output_list)):
+                top_level_output_list[i]["value"] = self.serialize_output(results[i], top_level_output_list[i])
+        elif isinstance(results, dict):
+            # pop the exit code if it exists inside the dictionary
+            exit_code = results.pop("exit_code", None)
+            if exit_code:
+                # If there's an exit_code, handle it (dict or int)
+                if isinstance(exit_code, dict):
+                    exit_code = ExitCode(exit_code["status"], exit_code["message"])
+                elif isinstance(exit_code, int):
+                    exit_code = ExitCode(exit_code)
+                if exit_code.status != 0:
+                    return exit_code
+            if len(top_level_output_list) == 1:
+                # If output name in results, use it
+                if top_level_output_list[0]["name"] in results:
+                    top_level_output_list[0]["value"] = self.serialize_output(
+                        results.pop(top_level_output_list[0]["name"]),
+                        top_level_output_list[0],
+                    )
+                    # If there are any extra keys in `results`, log a warning
+                    if len(results) > 0:
+                        self.logger.warning(
+                            f"Found extra results that are not included in the output: {results.keys()}"
+                        )
+                else:
+                    # Otherwise assume the entire dict is the single output
+                    top_level_output_list[0]["value"] = self.serialize_output(results, top_level_output_list[0])
+            elif len(top_level_output_list) > 1:
+                # Match each top-level output by name
+                for output in top_level_output_list:
+                    if output["name"] not in results:
+                        if output.get("required", True):
+                            return self.exit_codes.ERROR_MISSING_OUTPUT
+                    else:
+                        output["value"] = self.serialize_output(results.pop(output["name"]), output)
+                # Any remaining results are unaccounted for -> log a warning
+                if len(results) > 0:
+                    self.logger.warning(f"Found extra results that are not included in the output: {results.keys()}")
+        elif len(top_level_output_list) == 1:
+            # Single top-level output, single result
+            top_level_output_list[0]["value"] = self.serialize_output(results, top_level_output_list[0])
+        else:
+            return self.exit_codes.ERROR_RESULT_OUTPUT_MISMATCH
+        # Store the outputs
+        for output in top_level_output_list:
+            self.out(output["name"], output["value"])
+
+        return ExitCode()
+
+    def find_output(self, name):
+        """Find the output spec with the given name."""
+        for output in self.output_list:
+            if output["name"] == name:
+                return output
+        return None
+
+    def serialize_output(self, result, output):
+        """Serialize outputs."""
+        from aiida_pythonjob.data.serializer import general_serializer
+
+        name = output["name"]
+        if output.get("identifier", "Any").upper() == "NAMESPACE":
+            if isinstance(result, dict):
+                serialized_result = {}
+                for key, value in result.items():
+                    full_name = f"{name}.{key}"
+                    full_name_output = self.find_output(full_name)
+                    if full_name_output and full_name_output.get("identifier", "Any").upper() == "NAMESPACE":
+                        serialized_result[key] = self.serialize_output(value, full_name_output)
+                    else:
+                        serialized_result[key] = general_serializer(value, serializers=self.serializers, store=False)
+                return serialized_result
+            else:
+                self.logger.error(f"Expected a dict for namespace '{name}', got {type(result)}.")
+                return self.exit_codes.ERROR_INVALID_OUTPUT
+        else:
+            return general_serializer(result, serializers=self.serializers, store=False)

--- a/src/aiida_pythonjob/data/serializer.py
+++ b/src/aiida_pythonjob/data/serializer.py
@@ -86,7 +86,11 @@ def clean_dict_key(data):
 
 
 def general_serializer(
-    data: Any, serializers: dict | None = None, deserializers: dict | None = None, check_value=True
+    data: Any,
+    serializers: dict | None = None,
+    deserializers: dict | None = None,
+    check_value=True,
+    store=True,
 ) -> orm.Node:
     """Serialize the data to an AiiDA data node."""
     updated_deserializers = all_deserializers.copy()
@@ -122,7 +126,8 @@ def general_serializer(
             try:
                 serializer = import_from_path(updated_serializers[ep_key])
                 new_node = serializer(data)
-                new_node.store()
+                if store:
+                    new_node.store()
                 return new_node
             except Exception:
                 error_traceback = traceback.format_exc()
@@ -131,7 +136,8 @@ def general_serializer(
             # try to serialize the data as a PickledData
             try:
                 new_node = PickledData(data)
-                new_node.store()
+                if store:
+                    new_node.store()
                 return new_node
             except Exception as e:
                 raise ValueError(f"Error in serializing {ep_key}: {e}")

--- a/src/aiida_pythonjob/data/serializer.py
+++ b/src/aiida_pythonjob/data/serializer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import traceback
 from importlib.metadata import entry_points
 from typing import Any
 
@@ -121,15 +122,11 @@ def general_serializer(
             try:
                 serializer = import_from_path(updated_serializers[ep_key])
                 new_node = serializer(data)
-            except Exception as e:
-                raise ValueError(f"Error in serializing {ep_key}: {e}")
-            finally:
-                # try to save the node to da
-                try:
-                    new_node.store()
-                    return new_node
-                except Exception:
-                    raise ValueError(f"Error in storing data {ep_key}")
+                new_node.store()
+                return new_node
+            except Exception:
+                error_traceback = traceback.format_exc()
+                raise ValueError(f"Error in serializing {ep_key}: {error_traceback}")
         else:
             # try to serialize the data as a PickledData
             try:

--- a/src/aiida_pythonjob/decorator.py
+++ b/src/aiida_pythonjob/decorator.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import functools
+import logging
+import signal
+import sys
+import typing as t
+from typing import Any, Mapping
+
+from aiida.engine.processes.functions import FunctionType, get_stack_size
+from aiida.manage import get_manager
+from aiida.orm import ProcessNode
+
+from aiida_pythonjob.calculations.pyfunction import PyFunction
+from aiida_pythonjob.launch import create_inputs, prepare_pyfunction_inputs
+
+LOGGER = logging.getLogger(__name__)
+
+
+# The following code is modified from the aiida-core.engine.processes.functions module
+def pyfunction(
+    outputs: t.Optional[t.List[Mapping[str, Any]]] = None,
+) -> t.Callable[[FunctionType], FunctionType]:
+    """The base function decorator to create a FunctionProcess out of a normal python function.
+
+    :param outputs: the outputs of the function, if not provided, we assume a single output named 'result'.
+    """
+
+    def decorator(function: FunctionType) -> FunctionType:
+        """Turn the decorated function into a FunctionProcess.
+
+        :param callable function: the actual decorated function that the FunctionProcess represents
+        :return callable: The decorated function.
+        """
+
+        def run_get_node(*args, **kwargs) -> tuple[dict[str, t.Any] | None, "ProcessNode"]:
+            """Run the FunctionProcess with the supplied inputs in a local runner.
+
+            :param args: input arguments to construct the FunctionProcess
+            :param kwargs: input keyword arguments to construct the FunctionProcess
+            :return: tuple of the outputs of the process and the process node
+            """
+            frame_delta = 1000
+            frame_count = get_stack_size()
+            stack_limit = sys.getrecursionlimit()
+            LOGGER.info("Executing process function, current stack status: %d frames of %d", frame_count, stack_limit)
+
+            # If the current frame count is more than 80% of the stack limit, or comes within 200 frames, increase the
+            # stack limit by ``frame_delta``.
+            if frame_count > min(0.8 * stack_limit, stack_limit - 200):
+                LOGGER.warning(
+                    "Current stack contains %d frames which is close to the limit of %d. Increasing the limit by %d",
+                    frame_count,
+                    stack_limit,
+                    frame_delta,
+                )
+                sys.setrecursionlimit(stack_limit + frame_delta)
+
+            manager = get_manager()
+            runner = manager.get_runner()
+            inputs = create_inputs(function, *args, **kwargs)
+            inputs = prepare_pyfunction_inputs(function=function, function_inputs=inputs, function_outputs=outputs)
+
+            # # Remove all the known inputs from the kwargs
+            # for port in process_class.spec().inputs:
+            #     kwargs.pop(port, None)
+
+            # # If any kwargs remain, the spec should be dynamic, so we raise if it isn't
+            # if kwargs and not process_class.spec().inputs.dynamic:
+            #     raise ValueError(f'{function.__name__} does not support these kwargs: {kwargs.keys()}')
+
+            process = PyFunction(inputs=inputs, runner=runner)
+
+            # Only add handlers for interrupt signal to kill the process if we are in a local and not a daemon runner.
+            # Without this check, running process functions in a daemon worker would be killed if the daemon is shutdown
+            current_runner = manager.get_runner()
+            original_handler = None
+            kill_signal = signal.SIGINT
+
+            if not current_runner.is_daemon_runner:
+
+                def kill_process(_num, _frame):
+                    """Send the kill signal to the process in the current scope."""
+                    LOGGER.critical("runner received interrupt, killing process %s", process.pid)
+                    result = process.kill(msg="Process was killed because the runner received an interrupt")
+                    return result
+
+                # Store the current handler on the signal such that it can be restored after process has terminated
+                original_handler = signal.getsignal(kill_signal)
+                signal.signal(kill_signal, kill_process)
+
+            try:
+                result = process.execute()
+            finally:
+                # If the `original_handler` is set, that means the `kill_process` was bound, which needs to be reset
+                if original_handler:
+                    signal.signal(signal.SIGINT, original_handler)
+
+            store_provenance = inputs.get("metadata", {}).get("store_provenance", True)
+            if not store_provenance:
+                process.node._storable = False
+                process.node._unstorable_message = "cannot store node because it was run with `store_provenance=False`"
+
+            return result, process.node
+
+        def run_get_pk(*args, **kwargs) -> tuple[dict[str, t.Any] | None, int]:
+            """Recreate the `run_get_pk` utility launcher.
+
+            :param args: input arguments to construct the FunctionProcess
+            :param kwargs: input keyword arguments to construct the FunctionProcess
+            :return: tuple of the outputs of the process and the process node pk
+
+            """
+            result, node = run_get_node(*args, **kwargs)
+            assert node.pk is not None
+            return result, node.pk
+
+        @functools.wraps(function)
+        def decorated_function(*args, **kwargs):
+            """This wrapper function is the actual function that is called."""
+            result, _ = run_get_node(*args, **kwargs)
+            return result
+
+        decorated_function.run = decorated_function  # type: ignore[attr-defined]
+        decorated_function.run_get_pk = run_get_pk  # type: ignore[attr-defined]
+        decorated_function.run_get_node = run_get_node  # type: ignore[attr-defined]
+        decorated_function.is_process_function = True  # type: ignore[attr-defined]
+        decorated_function.process_class = PyFunction  # type: ignore[attr-defined]
+        decorated_function.recreate_from = PyFunction.recreate_from  # type: ignore[attr-defined]
+        decorated_function.spec = PyFunction.spec  # type: ignore[attr-defined]
+
+        return decorated_function  # type: ignore[return-value]
+
+    return decorator

--- a/tests/test_pyfunction.py
+++ b/tests/test_pyfunction.py
@@ -1,0 +1,87 @@
+from aiida.engine import run_get_node
+from aiida_pythonjob import pyfunction
+
+
+def test_function_default_outputs():
+    """Test decorator."""
+
+    @pyfunction()
+    def add(x, y):
+        return x + y
+
+    result, node = run_get_node(add, x=1, y=2)
+
+    assert result.value == 3
+    assert node.process_label == "add"
+
+
+def test_function_custom_outputs():
+    """Test decorator."""
+
+    @pyfunction(
+        outputs=[
+            {"name": "sum"},
+            {"name": "diff"},
+        ]
+    )
+    def add(x, y):
+        return {"sum": x + y, "diff": x - y}
+
+    result, node = run_get_node(add, x=1, y=2)
+
+    assert result["sum"].value == 3
+    assert result["diff"].value == -1
+    assert node.process_label == "add"
+
+
+def test_importable_function():
+    """Test importable function."""
+    from ase.build import bulk
+
+    result, _ = run_get_node(pyfunction()(bulk), name="Si")
+    assert result.value.get_chemical_formula() == "Si2"
+
+
+def test_kwargs_inputs():
+    """Test function with kwargs."""
+
+    @pyfunction(outputs=[{"name": "sum"}])
+    def add(x, y=1, **kwargs):
+        x += y
+        for value in kwargs.values():
+            x += value
+        return x
+
+    result, _ = run_get_node(add, x=1, y=2, a=3, b=4)
+    assert result["sum"].value == 10
+
+
+def test_namespace_output():
+    """Test function with namespace output and input."""
+
+    @pyfunction(
+        outputs=[
+            {
+                "name": "add_multiply",
+                "identifier": "namespace",
+            },
+            {
+                "name": "add_multiply.add",
+                "identifier": "namespace",
+            },
+            {"name": "minus"},
+        ]
+    )
+    def myfunc(x, y):
+        add = {"order1": x + y, "order2": x * x + y * y}
+        return {
+            "add_multiply": {"add": add, "multiply": x * y},
+            "minus": x - y,
+        }
+
+    result, node = run_get_node(myfunc, x=1, y=2)
+    print("result: ", result)
+
+    assert result["add_multiply"]["add"]["order1"].value == 3
+    assert result["add_multiply"]["add"]["order2"].value == 5
+    assert result["add_multiply"]["multiply"].value == 2


### PR DESCRIPTION
- Add `PyFunction` process and `@pyfunction` decorator for running pure Python functions locally within AiiDA.
- Automatically serializes inputs and deserializes outputs, enabling use of native Python types.

Here is an example:
```python
from aiida.engine import run_get_node
from aiida_pythonjob.decorator import pyfunction
from aiida import load_profile
from ase.build import bulk

load_profile()

@pyfunction(outputs=[{"name": "supercell"}, {"name": "original"}])
def make_supercell(atoms, dims=[2, 2, 2]):
    return {"supercell": atoms*dims, "original": atoms}

atoms = bulk('Si')
result, node = run_get_node(make_supercell, atoms=atoms, dims=[2, 2, 2])
print("result: ", result)
```
