### PR TITLE
Refactor parser

### DIFF
--- a/docs/gallery/autogen/pyfunction.py
+++ b/docs/gallery/autogen/pyfunction.py
@@ -30,7 +30,7 @@ print("result: ", result)
 # Custom outputs
 # --------------
 # If the function return a dictionary with fixed number of keys, and you
-# want to store the values as separate outputs, you can specify the `output_ports` parameter.
+# want to store the values as separate outputs, you can specify the `outputs` parameter.
 # For a dynamic number of outputs, you can use the namespace output, which is explained later.
 #
 

--- a/docs/gallery/autogen/pyfunction.py
+++ b/docs/gallery/autogen/pyfunction.py
@@ -30,7 +30,7 @@ print("result: ", result)
 # Custom outputs
 # --------------
 # If the function return a dictionary with fixed number of keys, and you
-# want to store the values as separate outputs, you can specify the `function_outputs` parameter.
+# want to store the values as separate outputs, you can specify the `output_ports` parameter.
 # For a dynamic number of outputs, you can use the namespace output, which is explained later.
 #
 

--- a/docs/gallery/autogen/pythonjob.py
+++ b/docs/gallery/autogen/pythonjob.py
@@ -91,7 +91,7 @@ print("result: ", result["result"])
 # Custom outputs
 # --------------
 # If the function return a dictionary with fixed number of keys, and you
-# want to store the values as separate outputs, you can specify the `function_outputs` parameter.
+# want to store the values as separate outputs, you can specify the `output_ports` parameter.
 # For a dynamic number of outputs, you can use the namespace output, which is explained later.
 #
 
@@ -103,7 +103,7 @@ def add(x, y):
 inputs = prepare_pythonjob_inputs(
     add,
     function_inputs={"x": 1, "y": 2},
-    function_outputs=[
+    output_ports=[
         {"name": "sum"},
         {"name": "diff"},
     ],
@@ -142,7 +142,7 @@ def multiply(x, y):
 inputs1 = prepare_pythonjob_inputs(
     add,
     function_inputs={"x": 1, "y": 2},
-    function_outputs=[{"name": "sum"}],
+    output_ports=[{"name": "sum"}],
 )
 
 result1, node1 = run_get_node(PythonJob, inputs=inputs1)
@@ -150,7 +150,7 @@ result1, node1 = run_get_node(PythonJob, inputs=inputs1)
 inputs2 = prepare_pythonjob_inputs(
     multiply,
     function_inputs={"x": 1, "y": 2},
-    function_outputs=[{"name": "product"}],
+    output_ports=[{"name": "product"}],
     parent_folder=result1["remote_folder"],
 )
 
@@ -270,7 +270,7 @@ def generate_structures(structure: Atoms, factor_lst: list) -> dict:
 inputs = prepare_pythonjob_inputs(
     generate_structures,
     function_inputs={"structure": bulk("Al"), "factor_lst": [0.95, 1.0, 1.05]},
-    function_outputs=[{"name": "scaled_structures", "identifier": "namespace"}],
+    output_ports=[{"name": "scaled_structures", "identifier": "namespace"}],
 )
 
 result, node = run_get_node(PythonJob, inputs=inputs)

--- a/examples/test_add.py
+++ b/examples/test_add.py
@@ -10,6 +10,6 @@ def add(x, y):
 
 
 inputs = prepare_pythonjob_inputs(
-    add, function_inputs={"x": 1, "y": 2}, function_outputs=[{"name": "add"}], computer="localhost"
+    add, function_inputs={"x": 1, "y": 2}, output_ports=[{"name": "add"}], computer="localhost"
 )
 run(PythonJob, inputs=inputs)

--- a/src/aiida_pythonjob/calculations/pyfunction.py
+++ b/src/aiida_pythonjob/calculations/pyfunction.py
@@ -49,7 +49,8 @@ class PyFunction(Process):
         """Define the process specification, including its inputs, outputs and known exit codes."""
         super().define(spec)
         spec.input_namespace("function_data", dynamic=True, required=True)
-        spec.input("function_data.outputs", valid_type=List, serializer=to_aiida_type, required=False)
+        spec.input("function_data.output_ports", valid_type=List, serializer=to_aiida_type, required=False)
+        spec.input("function_data.input_ports", valid_type=List, serializer=to_aiida_type, required=False)
         spec.input("process_label", valid_type=Str, serializer=to_aiida_type, required=False)
         spec.input_namespace("function_inputs", valid_type=Data, required=False)
         spec.input(
@@ -174,12 +175,12 @@ class PyFunction(Process):
 
         results = self.func(*raw_args, **raw_kwargs)
 
-        # Read function_outputs specification
-        if "outputs" in self.inputs.function_data:
-            function_outputs = self.node.inputs.function_data.outputs.get_list()
+        # Read output_ports specification
+        if "output_ports" in self.inputs.function_data:
+            output_ports = self.node.inputs.function_data.output_ports.get_list()
         else:
-            function_outputs = [{"name": "result"}]
-        self.output_list = function_outputs
+            output_ports = [{"name": "result"}]
+        self.output_list = output_ports
 
         # If nested outputs like "add_multiply.add", keep only top-level
         top_level_output_list = [output for output in self.output_list if "." not in output["name"]]

--- a/src/aiida_pythonjob/calculations/pyfunction.py
+++ b/src/aiida_pythonjob/calculations/pyfunction.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import inspect
+import traceback
 import typing as t
 
 from aiida.common.lang import override
@@ -12,7 +12,6 @@ from aiida.orm import (
     CalcFunctionNode,
     Data,
     Dict,
-    List,
     Str,
     to_aiida_type,
 )
@@ -20,11 +19,6 @@ from aiida.orm import (
 __all__ = ("PyFunction",)
 
 
-# The following code is modified from the aiida-core.engine.processes.functions module
-
-
-# TODO: because aiida-core cmds hardcode `CalcFunctionNode`, I hardcoded `CalcFunctionNode` here.
-# In principle, aiida-core should support subclassing
 class PyFunction(Process):
     """"""
 
@@ -49,8 +43,8 @@ class PyFunction(Process):
         """Define the process specification, including its inputs, outputs and known exit codes."""
         super().define(spec)
         spec.input_namespace("function_data", dynamic=True, required=True)
-        spec.input("function_data.output_ports", valid_type=List, serializer=to_aiida_type, required=False)
-        spec.input("function_data.input_ports", valid_type=List, serializer=to_aiida_type, required=False)
+        spec.input("function_data.output_ports", valid_type=Dict, serializer=to_aiida_type, required=False)
+        spec.input("function_data.input_ports", valid_type=Dict, serializer=to_aiida_type, required=False)
         spec.input("process_label", valid_type=Str, serializer=to_aiida_type, required=False)
         spec.input_namespace("function_inputs", valid_type=Data, required=False)
         spec.input(
@@ -82,6 +76,18 @@ class PyFunction(Process):
             "ERROR_RESULT_OUTPUT_MISMATCH",
             invalidates_cache=True,
             message="The number of results does not match the number of outputs.",
+        )
+        spec.exit_code(
+            323,
+            "ERROR_DESERIALIZE_INPUTS_FAILED",
+            invalidates_cache=True,
+            message="Failed to unpickle inputs.\n{exception}\n{traceback}",
+        )
+        spec.exit_code(
+            325,
+            "ERROR_FUNCTION_EXECUTION_FAILED",
+            invalidates_cache=True,
+            message="Function execution failed.\n{exception}\n{traceback}",
         )
 
     def get_function_name(self) -> str:
@@ -123,24 +129,13 @@ class PyFunction(Process):
     @override
     def run(self) -> ExitCode | None:
         """Run the process."""
+        from aiida_pythonjob.utils import deserialize_ports
 
-        from aiida_pythonjob.data.deserializer import deserialize_to_raw_python_data
-
-        # The following conditional is required for the caching to properly work. Even if the source node has a process
-        # state of `Finished` the cached process will still enter the running state. The process state will have then
-        # been overridden by the engine to `Running` so we cannot check that, but if the `exit_status` is anything other
-        # than `None`, it should mean this node was taken from the cache, so the process should not be rerun.
+        # The following conditional is required for the caching to properly work.
+        # From the the calcfunction implementation in aiida-core
         if self.node.exit_status is not None:
             return ExitCode(self.node.exit_status, self.node.exit_message)
 
-        # Now the original functions arguments need to be reconstructed from the inputs to the process, as they were
-        # passed to the original function call. To do so, all positional parameters are popped from the inputs
-        # dictionary and added to the positional arguments list.
-        args = []
-        kwargs: dict[str, Data] = {}
-        inputs = dict(self.inputs.function_inputs or {})
-        inputs.pop("serializers", None)
-        inputs.pop("deserializers", None)
         # load custom serializers
         if "serializers" in self.node.inputs and self.node.inputs.serializers:
             serializers = self.node.inputs.serializers.get_dict()
@@ -155,135 +150,46 @@ class PyFunction(Process):
         else:
             self.deserializers = None
 
-        for name, parameter in inspect.signature(self.func).parameters.items():
-            if parameter.kind in [parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD]:
-                if name in inputs:
-                    args.append(inputs.pop(name))
-            elif parameter.kind is parameter.VAR_POSITIONAL:
-                for key in [key for key in inputs.keys() if key.startswith(f"{name}_")]:
-                    args.append(inputs.pop(key))
+        inputs = dict(self.inputs.function_inputs or {})
+        try:
+            inputs = deserialize_ports(
+                serialized_data=inputs,
+                port_schema=self.node.inputs.function_data.input_ports.get_dict(),
+                deserializers=self.deserializers,
+            )
+        except Exception as exception:
+            exception_message = str(exception)
+            traceback_str = traceback.format_exc()
+            return self.exit_codes.ERROR_DESERIALIZE_INPUTS_FAILED.format(
+                exception=exception_message, traceback=traceback_str
+            )
 
-        # Any inputs that correspond to metadata ports were not part of the original function signature but were added
-        # by the process function decorator, so these have to be removed.
-        for key in [key for key, port in self.spec().inputs.items() if port.is_metadata]:
-            inputs.pop(key, None)
+        try:
+            results = self.func(**inputs)
+        except Exception as exception:
+            exception_message = str(exception)
+            traceback_str = traceback.format_exc()
+            return self.exit_codes.ERROR_FUNCTION_EXECUTION_FAILED.format(
+                exception=exception_message, traceback=traceback_str
+            )
+        return self.parse(results)
 
-        # The remaining inputs have to be keyword arguments.
-        kwargs.update(**inputs)
-        raw_args = [deserialize_to_raw_python_data(x, deserializers=self.deserializers) for x in args]
-        raw_kwargs = {k: deserialize_to_raw_python_data(v, deserializers=self.deserializers) for k, v in kwargs.items()}
+    def parse(self, results):
+        """Parse the results of the function."""
+        from aiida_pythonjob.utils import parse_outputs
 
-        results = self.func(*raw_args, **raw_kwargs)
-
-        # Read output_ports specification
-        if "output_ports" in self.inputs.function_data:
-            output_ports = self.node.inputs.function_data.output_ports.get_list()
-        else:
-            output_ports = [{"name": "result"}]
-        self.output_list = output_ports
-
-        # If nested outputs like "add_multiply.add", keep only top-level
-        top_level_output_list = [output for output in self.output_list if "." not in output["name"]]
-        if isinstance(results, tuple):
-            if len(top_level_output_list) != len(results):
-                return self.exit_codes.ERROR_RESULT_OUTPUT_MISMATCH
-            for i in range(len(top_level_output_list)):
-                top_level_output_list[i]["value"] = self.serialize_output(results[i], top_level_output_list[i])
-        elif isinstance(results, dict):
-            # pop the exit code if it exists inside the dictionary
-            exit_code = results.pop("exit_code", None)
-            if exit_code:
-                # If there's an exit_code, handle it (dict or int)
-                if isinstance(exit_code, dict):
-                    exit_code = ExitCode(exit_code["status"], exit_code["message"])
-                elif isinstance(exit_code, int):
-                    exit_code = ExitCode(exit_code)
-                if exit_code.status != 0:
-                    return exit_code
-            if len(top_level_output_list) == 1:
-                # User returned a single (nested) dict with AiiDA data nodes as values
-                if self.already_serialized(results):
-                    top_level_output_list = [{"name": key, "value": value} for key, value in results.items()]
-                elif top_level_output_list[0]["name"] in results:
-                    top_level_output_list[0]["value"] = self.serialize_output(
-                        results.pop(top_level_output_list[0]["name"]),
-                        top_level_output_list[0],
-                    )
-                    # If there are any extra keys in `results`, log a warning
-                    if len(results) > 0:
-                        self.logger.warning(
-                            f"Found extra results that are not included in the output: {results.keys()}"
-                        )
-                else:
-                    # Otherwise assume the entire dict is the single output
-                    top_level_output_list[0]["value"] = self.serialize_output(results, top_level_output_list[0])
-            elif len(top_level_output_list) > 1:
-                # Match each top-level output by name
-                for output in top_level_output_list:
-                    if output["name"] not in results:
-                        if output.get("required", True):
-                            return self.exit_codes.ERROR_MISSING_OUTPUT
-                    else:
-                        output["value"] = self.serialize_output(results.pop(output["name"]), output)
-                # Any remaining results are unaccounted for -> log a warning
-                if len(results) > 0:
-                    self.logger.warning(f"Found extra results that are not included in the output: {results.keys()}")
-        elif len(top_level_output_list) == 1:
-            # Single top-level output
-            # There are two cases:
-            # 1. The output as a whole will be serialized as the single output
-            # 2. The output is a mapping with already AiiDA data nodes as values, no need to serialize
-            if self.already_serialized(results):
-                top_level_output_list[0]["value"] = results
-            else:
-                top_level_output_list[0]["value"] = self.serialize_output(results, top_level_output_list[0])
-        else:
-            return self.exit_codes.ERROR_RESULT_OUTPUT_MISMATCH
+        self.output_ports = self.node.inputs.function_data.output_ports.get_dict()
+        exit_code = parse_outputs(
+            results,
+            output_ports=self.output_ports,
+            exit_codes=self.exit_codes,
+            logger=self.logger,
+            serializers=self.serializers,
+        )
+        if exit_code:
+            return exit_code
         # Store the outputs
-        for output in top_level_output_list:
+        for output in self.output_ports["ports"]:
             self.out(output["name"], output["value"])
 
         return ExitCode()
-
-    def already_serialized(self, results):
-        """Check if the results are already serialized."""
-        import collections
-
-        if isinstance(results, Data):
-            return True
-        elif isinstance(results, collections.abc.Mapping):
-            for value in results.values():
-                if not self.already_serialized(value):
-                    return False
-            return True
-        else:
-            return False
-
-    def find_output(self, name):
-        """Find the output spec with the given name."""
-        for output in self.output_list:
-            if output["name"] == name:
-                return output
-        return None
-
-    def serialize_output(self, result, output):
-        """Serialize outputs."""
-        from aiida_pythonjob.data.serializer import general_serializer
-
-        name = output["name"]
-        if output.get("identifier", "Any").upper() == "NAMESPACE":
-            if isinstance(result, dict):
-                serialized_result = {}
-                for key, value in result.items():
-                    full_name = f"{name}.{key}"
-                    full_name_output = self.find_output(full_name)
-                    if full_name_output and full_name_output.get("identifier", "Any").upper() == "NAMESPACE":
-                        serialized_result[key] = self.serialize_output(value, full_name_output)
-                    else:
-                        serialized_result[key] = general_serializer(value, serializers=self.serializers, store=False)
-                return serialized_result
-            else:
-                self.logger.error(f"Expected a dict for namespace '{name}', got {type(result)}.")
-                return self.exit_codes.ERROR_INVALID_OUTPUT
-        else:
-            return general_serializer(result, serializers=self.serializers, store=False)

--- a/src/aiida_pythonjob/calculations/pythonjob.py
+++ b/src/aiida_pythonjob/calculations/pythonjob.py
@@ -45,7 +45,7 @@ class PythonJob(CalcJob):
         """Define the process specification, including its inputs, outputs and known exit codes."""
         super().define(spec)
         spec.input_namespace("function_data", dynamic=True, required=True)
-        spec.input("function_data.outputs", valid_type=List, serializer=to_aiida_type, required=False)
+        spec.input("function_data.output_ports", valid_type=List, serializer=to_aiida_type, required=False)
         spec.input("process_label", valid_type=Str, serializer=to_aiida_type, required=False)
         spec.input_namespace("function_inputs", valid_type=Data, required=False)
         spec.input(

--- a/src/aiida_pythonjob/calculations/pythonjob.py
+++ b/src/aiida_pythonjob/calculations/pythonjob.py
@@ -45,7 +45,8 @@ class PythonJob(CalcJob):
         """Define the process specification, including its inputs, outputs and known exit codes."""
         super().define(spec)
         spec.input_namespace("function_data", dynamic=True, required=True)
-        spec.input("function_data.output_ports", valid_type=List, serializer=to_aiida_type, required=False)
+        spec.input("function_data.input_ports", valid_type=Dict, serializer=to_aiida_type, required=False)
+        spec.input("function_data.output_ports", valid_type=Dict, serializer=to_aiida_type, required=False)
         spec.input("process_label", valid_type=Str, serializer=to_aiida_type, required=False)
         spec.input_namespace("function_inputs", valid_type=Data, required=False)
         spec.input(

--- a/src/aiida_pythonjob/data/deserializer.py
+++ b/src/aiida_pythonjob/data/deserializer.py
@@ -5,7 +5,8 @@ from typing import Any
 from aiida import common, orm
 
 from aiida_pythonjob.config import load_config
-from aiida_pythonjob.utils import import_from_path
+
+from .utils import import_from_path
 
 builtin_deserializers = {
     "aiida.orm.nodes.data.list.List": "aiida_pythonjob.data.deserializer.list_data_to_list",

--- a/src/aiida_pythonjob/data/serializer.py
+++ b/src/aiida_pythonjob/data/serializer.py
@@ -8,10 +8,10 @@ from typing import Any
 from aiida import common, orm
 
 from aiida_pythonjob.config import load_config
-from aiida_pythonjob.utils import import_from_path
 
 from .deserializer import all_deserializers
 from .pickled_data import PickledData
+from .utils import import_from_path
 
 
 def atoms_to_structure_data(structure):

--- a/src/aiida_pythonjob/data/utils.py
+++ b/src/aiida_pythonjob/data/utils.py
@@ -1,0 +1,11 @@
+import importlib
+from typing import Any
+
+
+def import_from_path(path: str) -> Any:
+    module_name, object_name = path.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    try:
+        return getattr(module, object_name)
+    except AttributeError:
+        raise AttributeError(f"{object_name} not found in module {module_name}.")

--- a/src/aiida_pythonjob/decorator.py
+++ b/src/aiida_pythonjob/decorator.py
@@ -59,23 +59,29 @@ def pyfunction(
 
             manager = get_manager()
             runner = manager.get_runner()
-            output_ports = kwargs.pop("output_ports", {}) or outputs
-            input_ports = kwargs.pop("input_ports", {}) or inputs
+            # # Remove all the known inputs from the kwargs
+            output_ports = kwargs.pop("output_ports", None) or outputs
+            input_ports = kwargs.pop("input_ports", None) or inputs
+            metadata = kwargs.pop("metadata", None)
+            function_data = kwargs.pop("function_data", None)
+            deserializers = kwargs.pop("deserializers", None)
+            serializers = kwargs.pop("serializers", None)
+            process_label = kwargs.pop("process_label", None)
+            register_pickle_by_value = kwargs.pop("register_pickle_by_value", False)
+
             function_inputs = create_inputs(function, *args, **kwargs)
             process_inputs = prepare_pyfunction_inputs(
                 function=function,
                 function_inputs=function_inputs,
-                output_ports=output_ports,
                 input_ports=input_ports,
+                output_ports=output_ports,
+                metadata=metadata,
+                process_label=process_label,
+                function_data=function_data,
+                deserializers=deserializers,
+                serializers=serializers,
+                register_pickle_by_value=register_pickle_by_value,
             )
-
-            # # Remove all the known inputs from the kwargs
-            # for port in process_class.spec().inputs:
-            #     kwargs.pop(port, None)
-
-            # # If any kwargs remain, the spec should be dynamic, so we raise if it isn't
-            # if kwargs and not process_class.spec().inputs.dynamic:
-            #     raise ValueError(f'{function.__name__} does not support these kwargs: {kwargs.keys()}')
 
             process = PyFunction(inputs=process_inputs, runner=runner)
 

--- a/src/aiida_pythonjob/parsers/pythonjob.py
+++ b/src/aiida_pythonjob/parsers/pythonjob.py
@@ -2,8 +2,9 @@
 
 import json
 
-from aiida.engine import ExitCode
 from aiida.parsers.parser import Parser
+
+from aiida_pythonjob.utils import parse_outputs
 
 # Map error_type from script.py to exit code label
 ERROR_TYPE_TO_EXIT_CODE = {
@@ -22,11 +23,7 @@ class PythonJobParser(Parser):
         import pickle
 
         # Read output_ports specification
-        if "output_ports" in self.node.inputs.function_data:
-            output_ports = self.node.inputs.function_data.output_ports.get_list()
-        else:
-            output_ports = [{"name": "result"}]
-        self.output_ports = output_ports
+        self.output_ports = self.node.inputs.function_data.output_ports.get_dict()
 
         # load custom serializers
         if "serializers" in self.node.inputs and self.node.inputs.serializers:
@@ -36,14 +33,21 @@ class PythonJobParser(Parser):
         else:
             self.serializers = None
 
-        # If nested outputs like "add_multiply.add", keep only top-level
-        top_level_output_list = [output for output in self.output_ports if "." not in output["name"]]
-
         # 1) Read _error.json
-        error_data = {}
         try:
             with self.retrieved.base.repository.open("_error.json", "r") as ef:
                 error_data = json.load(ef)
+                # If error_data is non-empty, we have an error from the script
+                if error_data:
+                    error_type = error_data.get("error_type", "UNKNOWN_ERROR")
+                    exception_message = error_data.get("exception_message", "")
+                    traceback_str = error_data.get("traceback", "")
+
+                    # Default to a generic code if we can't match a known error_type
+                    exit_code_label = ERROR_TYPE_TO_EXIT_CODE.get(error_type, "ERROR_SCRIPT_FAILED")
+
+                    # Use `.format()` to inject the exception and traceback
+                    return self.exit_codes[exit_code_label].format(exception=exception_message, traceback=traceback_str)
         except OSError:
             # No _error.json file found
             pass
@@ -51,78 +55,24 @@ class PythonJobParser(Parser):
             self.logger.error(f"Error reading _error.json: {exc}")
             return self.exit_codes.ERROR_INVALID_OUTPUT  # or a different exit code
 
-        # If error_data is non-empty, we have an error from the script
-        if error_data:
-            error_type = error_data.get("error_type", "UNKNOWN_ERROR")
-            exception_message = error_data.get("exception_message", "")
-            traceback_str = error_data.get("traceback", "")
-
-            # Default to a generic code if we can't match a known error_type
-            exit_code_label = ERROR_TYPE_TO_EXIT_CODE.get(error_type, "ERROR_SCRIPT_FAILED")
-
-            # Use `.format()` to inject the exception and traceback
-            return self.exit_codes[exit_code_label].format(exception=exception_message, traceback=traceback_str)
         # 2) If we reach here, _error.json exists but is empty or doesn't exist at all -> no error recorded
         #    Proceed with parsing results.pickle
         try:
             with self.retrieved.base.repository.open("results.pickle", "rb") as handle:
                 results = pickle.load(handle)
 
-                if isinstance(results, tuple):
-                    if len(top_level_output_list) != len(results):
-                        return self.exit_codes.ERROR_RESULT_OUTPUT_MISMATCH
-                    for i in range(len(top_level_output_list)):
-                        top_level_output_list[i]["value"] = self.serialize_output(results[i], top_level_output_list[i])
-
-                elif isinstance(results, dict):
-                    # pop the exit code if it exists inside the dictionary
-                    exit_code = results.pop("exit_code", None)
-                    if exit_code:
-                        # If there's an exit_code, handle it (dict or int)
-                        if isinstance(exit_code, dict):
-                            exit_code = ExitCode(exit_code["status"], exit_code["message"])
-                        elif isinstance(exit_code, int):
-                            exit_code = ExitCode(exit_code)
-                        if exit_code.status != 0:
-                            return exit_code
-
-                    if len(top_level_output_list) == 1:
-                        # If output name in results, use it
-                        if top_level_output_list[0]["name"] in results:
-                            top_level_output_list[0]["value"] = self.serialize_output(
-                                results.pop(top_level_output_list[0]["name"]),
-                                top_level_output_list[0],
-                            )
-                            # If there are any extra keys in `results`, log a warning
-                            if len(results) > 0:
-                                self.logger.warning(
-                                    f"Found extra results that are not included in the output: {results.keys()}"
-                                )
-                        else:
-                            # Otherwise assume the entire dict is the single output
-                            top_level_output_list[0]["value"] = self.serialize_output(results, top_level_output_list[0])
-                    elif len(top_level_output_list) > 1:
-                        # Match each top-level output by name
-                        for output in top_level_output_list:
-                            if output["name"] not in results:
-                                if output.get("required", True):
-                                    return self.exit_codes.ERROR_MISSING_OUTPUT
-                            else:
-                                output["value"] = self.serialize_output(results.pop(output["name"]), output)
-                        # Any remaining results are unaccounted for -> log a warning
-                        if len(results) > 0:
-                            self.logger.warning(
-                                f"Found extra results that are not included in the output: {results.keys()}"
-                            )
-
-                elif len(top_level_output_list) == 1:
-                    # Single top-level output, single result
-                    top_level_output_list[0]["value"] = self.serialize_output(results, top_level_output_list[0])
-                else:
-                    return self.exit_codes.ERROR_RESULT_OUTPUT_MISMATCH
+                exit_code = parse_outputs(
+                    results,
+                    output_ports=self.output_ports,
+                    exit_codes=self.exit_codes,
+                    logger=self.logger,
+                    serializers=self.serializers,
+                )
+                if exit_code:
+                    return exit_code
 
                 # Store the outputs
-                for output in top_level_output_list:
+                for output in self.output_ports["ports"]:
                     self.out(output["name"], output["value"])
 
         except OSError:
@@ -130,32 +80,3 @@ class PythonJobParser(Parser):
         except ValueError as exception:
             self.logger.error(exception)
             return self.exit_codes.ERROR_INVALID_OUTPUT
-
-    def find_output(self, name):
-        """Find the output spec with the given name."""
-        for output in self.output_ports:
-            if output["name"] == name:
-                return output
-        return None
-
-    def serialize_output(self, result, output):
-        """Serialize outputs."""
-        from aiida_pythonjob.data.serializer import general_serializer
-
-        name = output["name"]
-        if output.get("identifier", "Any").upper() == "NAMESPACE":
-            if isinstance(result, dict):
-                serialized_result = {}
-                for key, value in result.items():
-                    full_name = f"{name}.{key}"
-                    full_name_output = self.find_output(full_name)
-                    if full_name_output and full_name_output.get("identifier", "Any").upper() == "NAMESPACE":
-                        serialized_result[key] = self.serialize_output(value, full_name_output)
-                    else:
-                        serialized_result[key] = general_serializer(value, serializers=self.serializers)
-                return serialized_result
-            else:
-                self.logger.error(f"Expected a dict for namespace '{name}', got {type(result)}.")
-                return self.exit_codes.ERROR_INVALID_OUTPUT
-        else:
-            return general_serializer(result, serializers=self.serializers)

--- a/src/aiida_pythonjob/parsers/pythonjob.py
+++ b/src/aiida_pythonjob/parsers/pythonjob.py
@@ -21,12 +21,12 @@ class PythonJobParser(Parser):
     def parse(self, **kwargs):
         import pickle
 
-        # Read function_outputs specification
-        if "outputs" in self.node.inputs.function_data:
-            function_outputs = self.node.inputs.function_data.outputs.get_list()
+        # Read output_ports specification
+        if "output_ports" in self.node.inputs.function_data:
+            output_ports = self.node.inputs.function_data.output_ports.get_list()
         else:
-            function_outputs = [{"name": "result"}]
-        self.output_list = function_outputs
+            output_ports = [{"name": "result"}]
+        self.output_ports = output_ports
 
         # load custom serializers
         if "serializers" in self.node.inputs and self.node.inputs.serializers:
@@ -37,7 +37,7 @@ class PythonJobParser(Parser):
             self.serializers = None
 
         # If nested outputs like "add_multiply.add", keep only top-level
-        top_level_output_list = [output for output in self.output_list if "." not in output["name"]]
+        top_level_output_list = [output for output in self.output_ports if "." not in output["name"]]
 
         # 1) Read _error.json
         error_data = {}
@@ -133,7 +133,7 @@ class PythonJobParser(Parser):
 
     def find_output(self, name):
         """Find the output spec with the given name."""
-        for output in self.output_list:
+        for output in self.output_ports:
             if output["name"] == name:
                 return output
         return None

--- a/src/aiida_pythonjob/utils.py
+++ b/src/aiida_pythonjob/utils.py
@@ -3,16 +3,8 @@ import inspect
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, _SpecialForm, get_type_hints
 
 from aiida.common.exceptions import NotExistent
+from aiida.engine import ExitCode
 from aiida.orm import Computer, InstalledCode, User, load_code, load_computer
-
-
-def import_from_path(path: str) -> Any:
-    module_name, object_name = path.rsplit(".", 1)
-    module = importlib.import_module(module_name)
-    try:
-        return getattr(module, object_name)
-    except AttributeError:
-        raise AttributeError(f"{object_name} not found in module {module_name}.")
 
 
 def get_required_imports(func: Callable) -> Dict[str, set]:
@@ -256,17 +248,252 @@ Please check!
 
 
 def format_input_output_ports(data):
-    new_data = []
-    # if the output is WORKGRAPH.NAMESPACE, we need to change it to NAMESPACE
-    for item in data:
-        if isinstance(item, str):
-            new_data.append({"name": item})
-        elif isinstance(item, dict):
-            identifier = item.get("identifier", "any")
-            if identifier.split(".")[-1].upper() == "NAMESPACE":
-                new_data.append({"name": item["name"], "identifier": "NAMESPACE"})
+    ports = data.get("ports", [])
+    if ports:
+        data["identifier"] = "NAMESPACE"
+        new_ports = []
+        for item in ports:
+            if isinstance(item, str):
+                new_ports.append({"name": item, "identifier": "ANY"})
+            elif isinstance(item, dict):
+                item.setdefault("identifier", "any")
+                # if the output is WORKGRAPH.NAMESPACE, we need to change it to NAMESPACE
+                if item["identifier"].split(".")[-1].upper() == "NAMESPACE":
+                    item["identifier"] = "NAMESPACE"
+                    new_ports.append(format_input_output_ports(item))
+                else:
+                    new_ports.append(item)
             else:
-                new_data.append({"name": item["name"], "identifier": identifier})
+                raise ValueError(f"Invalid schema: {item}")
+        data["ports"] = new_ports
+    else:
+        data.setdefault("identifier", "ANY")
+    return data
+
+
+def build_input_port_definitions(
+    func,
+    input_ports: Optional[List[Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Build a list of port definitions from a function signature, then merge
+    user-defined ports that may override or add to them.
+
+    Return: A list of dicts, each at least has:
+      - "name":  str
+      - "identifier": str   (e.g. "ANY" or "NAMESPACE")
+      - possibly other keys like "required", etc.
+    """
+    import inspect
+
+    signature = inspect.signature(func)
+    default_ports = []
+
+    for param_name, param in signature.parameters.items():
+        if param.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            default_ports.append(
+                {"name": param_name, "identifier": "ANY", "required": param.default is inspect.Parameter.empty}
+            )
+        elif param.kind == inspect.Parameter.VAR_POSITIONAL:
+            # This is *args
+            raise NotImplementedError("Variable positional arguments are not yet supported")
+        elif param.kind == inspect.Parameter.VAR_KEYWORD:
+            # This is **kwargs
+            default_ports.append({"name": param_name, "identifier": "NAMESPACE", "required": False})
         else:
-            raise ValueError(f"Invalid schema: {item}")
-    return new_data
+            raise ValueError(f"Unsupported parameter kind: {param.kind}")
+
+    # Now merge in user-defined overrides or additions
+    user_defined_ports = input_ports.get("ports", []) if input_ports else []
+
+    # Convert default list to a dict by name for easy merging
+    merged_dict = {port["name"]: port for port in default_ports}
+    for user_port in user_defined_ports:
+        name = user_port["name"]
+        merged_dict[name] = {**merged_dict.get(name, {}), **user_port}
+
+    # Return the final merged list
+    input_ports["ports"] = list(merged_dict.values())
+    return input_ports
+
+
+def serialize_ports(
+    python_data: Dict[str, Any],
+    port_schema: Dict[str, Any],
+    serializers: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """
+    Convert a raw Python dictionary of user inputs into a dictionary of AiiDA nodes,
+    according to a nested port_schema.
+
+    :param python_data:   The actual user data, e.g. {"my_namespace": {...}, "some_other_port": ...}.
+    :param port_schema:   A dict of port definition, may contain sub ports with each is a dict with at least:
+                          { "name": <str>, "identifier": "ANY" or "NAMESPACE", ... }
+                          If NAMESPACE, it may have "ports": <list of nested port definitions>.
+    :param serializers:   (Optional) custom mapping for specialized serialization.
+
+    :return: A dictionary with the same structure, but with AiiDA nodes (or nested dicts)
+             instead of raw Python values.
+    """
+    from aiida_pythonjob.data.serializer import general_serializer
+
+    if port_schema["identifier"].upper() == "NAMESPACE":
+        name = port_schema["name"]
+        if not isinstance(python_data, dict):
+            raise ValueError(f"Expected dict for namespace '{name}', got {type(python_data)}")
+        # Convert schema into a dict keyed by port name for convenience.
+        sub_port_map = {p["name"]: p for p in port_schema.get("ports", [])}
+        result = {}
+        for name, value in python_data.items():
+            sub_port = sub_port_map.get(name, {})
+            port_id = sub_port.get("identifier", "ANY").upper()
+            if port_id == "NAMESPACE":
+                result[name] = serialize_ports(value, sub_port, serializers=serializers)
+
+            else:
+                serialized = general_serializer(value, serializers=serializers, store=False)
+                result[name] = serialized
+    else:
+        serialized = general_serializer(python_data, serializers=serializers, store=False)
+        result = serialized
+
+    return result
+
+
+def deserialize_ports(
+    serialized_data: Dict[str, Any],
+    port_schema: Dict[str, Any],
+    deserializers: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """
+    Convert a dictionary of AiiDA data nodes (or nested dicts) back into raw Python objects,
+    according to the same nested port_schema.
+
+    :param serialized_data: The data stored in AiiDA, e.g.
+                            { "my_namespace": { "foo": <Int>, "bar": { "baz": <List> } }, ... }
+    :param port_schema:     The same schema that was used to serialize.
+    :param deserializers:   (Optional) custom mapping for specialized deserialization.
+
+    :return: A dictionary of raw Python values.
+    """
+    from aiida_pythonjob.data.deserializer import deserialize_to_raw_python_data
+
+    if port_schema["identifier"].upper() == "NAMESPACE":
+        name = port_schema["name"]
+        if not isinstance(serialized_data, dict):
+            raise ValueError(f"Expected dict for namespace '{name}', got {type(serialized_data)}")
+        sub_port_map = {p["name"]: p for p in port_schema.get("ports", [])}
+        result = {}
+        for name, node_or_subdict in serialized_data.items():
+            sub_port = sub_port_map.get(name, {})
+            port_id = sub_port.get("identifier", "ANY").upper()
+
+            if port_id == "NAMESPACE":
+                result[name] = deserialize_ports(node_or_subdict, sub_port, deserializers=deserializers)
+            else:
+                raw_value = deserialize_to_raw_python_data(node_or_subdict, deserializers=deserializers)
+                result[name] = raw_value
+    else:
+        raw_value = deserialize_to_raw_python_data(serialized_data, deserializers=deserializers)
+        result = raw_value
+
+    return result
+
+
+def already_serialized(results):
+    """Check if the results are already serialized."""
+    import collections
+
+    from aiida import orm
+
+    if isinstance(results, orm.Data):
+        return True
+    elif isinstance(results, collections.abc.Mapping):
+        for value in results.values():
+            if not already_serialized(value):
+                return False
+        return True
+    else:
+        return False
+
+
+def parse_outputs(
+    results: Any,
+    output_ports: Dict[str, Any],
+    exit_codes,
+    logger,
+    serializers: Optional[Dict[str, str]] = None,
+) -> Union[Dict[str, Any], ExitCode]:
+    """
+    Parse the "results" returned from a function or loaded from file,
+    given a schema of 'output_ports'."
+    """
+
+    # Read output_ports specification
+
+    if isinstance(results, tuple):
+        if len(output_ports["ports"]) != len(results):
+            return exit_codes.ERROR_RESULT_OUTPUT_MISMATCH
+        for i in range(len(output_ports["ports"])):
+            output_ports["ports"][i]["value"] = serialize_ports(
+                python_data=results[i], port_schema=output_ports["ports"][i], serializers=serializers
+            )
+    elif isinstance(results, dict):
+        # pop the exit code if it exists inside the dictionary
+        exit_code = results.pop("exit_code", None)
+        if exit_code:
+            # If there's an exit_code, handle it (dict or int)
+            if isinstance(exit_code, dict):
+                exit_code = ExitCode(exit_code["status"], exit_code["message"])
+            elif isinstance(exit_code, int):
+                exit_code = ExitCode(exit_code)
+            if exit_code.status != 0:
+                return exit_code
+        if len(output_ports["ports"]) == 1:
+            # User returned a single (nested) dict with AiiDA data nodes as values
+            if already_serialized(results):
+                output_ports["ports"] = [{"name": key, "value": value} for key, value in results.items()]
+            elif output_ports["ports"][0]["name"] in results:
+                output_ports["ports"][0]["value"] = serialize_ports(
+                    python_data=results.pop(output_ports["ports"][0]["name"]),
+                    port_schema=output_ports["ports"][0],
+                    serializers=serializers,
+                )
+                # If there are any extra keys in `results`, log a warning
+                if len(results) > 0:
+                    logger.warning(f"Found extra results that are not included in the output: {results.keys()}")
+            else:
+                # Otherwise assume the entire dict is the single output
+                output_ports["ports"][0]["value"] = serialize_ports(
+                    python_data=results, port_schema=output_ports["ports"][0], serializers=serializers
+                )
+        elif len(output_ports["ports"]) > 1:
+            # Match each top-level output by name
+            for output in output_ports["ports"]:
+                if output["name"] not in results:
+                    if output.get("required", True):
+                        return exit_codes.ERROR_MISSING_OUTPUT
+                else:
+                    output["value"] = serialize_ports(
+                        python_data=results.pop(output["name"]), port_schema=output, serializers=serializers
+                    )
+            # Any remaining results are unaccounted for -> log a warning
+            if len(results) > 0:
+                logger.warning(f"Found extra results that are not included in the output: {results.keys()}")
+    elif len(output_ports["ports"]) == 1:
+        # Single top-level output
+        # There are two cases:
+        # 1. The output as a whole will be serialized as the single output
+        # 2. The output is a mapping with already AiiDA data nodes as values, no need to serialize
+        if already_serialized(results):
+            output_ports["ports"][0]["value"] = results
+        else:
+            output_ports["ports"][0]["value"] = serialize_ports(
+                python_data=results, port_schema=output_ports["ports"][0], serializers=serializers
+            )
+    else:
+        return exit_codes.ERROR_RESULT_OUTPUT_MISMATCH

--- a/src/aiida_pythonjob/utils.py
+++ b/src/aiida_pythonjob/utils.py
@@ -253,3 +253,20 @@ Please check!
                 return True, "Environment setup is complete."
 
     return True, None
+
+
+def format_input_output_ports(data):
+    new_data = []
+    # if the output is WORKGRAPH.NAMESPACE, we need to change it to NAMESPACE
+    for item in data:
+        if isinstance(item, str):
+            new_data.append({"name": item})
+        elif isinstance(item, dict):
+            identifier = item.get("identifier", "any")
+            if identifier.split(".")[-1].upper() == "NAMESPACE":
+                new_data.append({"name": item["name"], "identifier": "NAMESPACE"})
+            else:
+                new_data.append({"name": item["name"], "identifier": identifier})
+        else:
+            raise ValueError(f"Invalid schema: {item}")
+    return new_data

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -49,7 +49,7 @@ def create_parser(result, function_data, error: dict | None = None, output_filen
 
 def test_tuple_result(fixture_localhost):
     result = (1, 2, 3)
-    function_data = {"outputs": orm.List([{"name": "a"}, {"name": "b"}, {"name": "c"}])}
+    function_data = {"output_ports": orm.List([{"name": "a"}, {"name": "b"}, {"name": "c"}])}
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code is None
@@ -58,7 +58,7 @@ def test_tuple_result(fixture_localhost):
 
 def test_tuple_result_mismatch(fixture_localhost):
     result = (1, 2)
-    function_data = {"outputs": orm.List([{"name": "a"}, {"name": "b"}, {"name": "c"}])}
+    function_data = {"output_ports": orm.List([{"name": "a"}, {"name": "b"}, {"name": "c"}])}
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code == parser.exit_codes.ERROR_RESULT_OUTPUT_MISMATCH
@@ -66,7 +66,7 @@ def test_tuple_result_mismatch(fixture_localhost):
 
 def test_dict_result(fixture_localhost):
     result = {"a": 1, "b": 2, "c": 3}
-    function_data = {"outputs": orm.List([{"name": "a"}, {"name": "b"}])}
+    function_data = {"output_ports": orm.List([{"name": "a"}, {"name": "b"}])}
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code is None
@@ -77,7 +77,7 @@ def test_dict_result(fixture_localhost):
 
 def test_dict_result_missing(fixture_localhost):
     result = {"a": 1, "b": 2}
-    function_data = {"outputs": orm.List([{"name": "a"}, {"name": "b"}, {"name": "c"}])}
+    function_data = {"output_ports": orm.List([{"name": "a"}, {"name": "b"}, {"name": "c"}])}
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code == parser.exit_codes.ERROR_MISSING_OUTPUT
@@ -85,7 +85,7 @@ def test_dict_result_missing(fixture_localhost):
 
 def test_dict_result_as_one_output(fixture_localhost):
     result = {"a": 1, "b": 2, "c": 3}
-    function_data = {"outputs": orm.List([{"name": "result"}])}
+    function_data = {"output_ports": orm.List([{"name": "result"}])}
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code is None
@@ -95,7 +95,7 @@ def test_dict_result_as_one_output(fixture_localhost):
 
 def test_dict_result_only_show_one_output(fixture_localhost):
     result = {"a": 1, "b": 2}
-    function_data = {"outputs": orm.List([{"name": "a"}])}
+    function_data = {"output_ports": orm.List([{"name": "a"}])}
     parser = create_parser(result, function_data)
     parser.parse()
     assert len(parser.outputs) == 1
@@ -106,14 +106,14 @@ def test_dict_result_only_show_one_output(fixture_localhost):
 
 def test_exit_code(fixture_localhost):
     result = {"a": 1, "exit_code": {"status": 0, "message": ""}}
-    function_data = {"outputs": orm.List([{"name": "a"}])}
+    function_data = {"output_ports": orm.List([{"name": "a"}])}
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code is None
     assert parser.outputs["a"] == 1
     #
     result = {"exit_code": {"status": 1, "message": "error"}}
-    function_data = {"outputs": orm.List([{"name": "a"}, {"name": "b"}, {"name": "c"}])}
+    function_data = {"output_ports": orm.List([{"name": "a"}, {"name": "b"}, {"name": "c"}])}
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code is not None
@@ -123,7 +123,7 @@ def test_exit_code(fixture_localhost):
 
 def test_no_output_file(fixture_localhost):
     result = {"a": 1, "b": 2, "c": 3}
-    function_data = {"outputs": orm.List([{"name": "result"}])}
+    function_data = {"output_ports": orm.List([{"name": "result"}])}
     parser = create_parser(result, function_data, output_filename="not_results.pickle")
     exit_code = parser.parse()
     assert exit_code == parser.exit_codes.ERROR_READING_OUTPUT_FILE
@@ -142,7 +142,7 @@ def test_no_output_file(fixture_localhost):
 def test_run_script_error(error_type, status):
     error = {"error_type": error_type, "exception_message": "error", "traceback": "traceback"}
     result = {"a": 1, "exit_code": {"status": 0, "message": ""}}
-    function_data = {"outputs": orm.List([{"name": "a"}])}
+    function_data = {"output_ports": orm.List([{"name": "a"}])}
     parser = create_parser(result, function_data, error=error)
     exit_code = parser.parse()
     assert exit_code is not None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,6 +10,16 @@ from aiida import orm
 from aiida.cmdline.utils.common import get_workchain_report
 from aiida.common.links import LinkType
 
+output_ports_with_multiple_sub_ports = {
+    "name": "outputs",
+    "identifier": "namespace",
+    "ports": [
+        {"name": "a", "identifier": "any"},
+        {"name": "b", "identifier": "any"},
+        {"name": "c", "identifier": "any"},
+    ],
+}
+
 
 def create_retrieved_folder(result: dict, error: dict | None = None, output_filename="results.pickle"):
     # Create a retrieved ``FolderData`` node with results
@@ -49,7 +59,7 @@ def create_parser(result, function_data, error: dict | None = None, output_filen
 
 def test_tuple_result(fixture_localhost):
     result = (1, 2, 3)
-    function_data = {"output_ports": orm.List([{"name": "a"}, {"name": "b"}, {"name": "c"}])}
+    function_data = {"output_ports": orm.Dict(output_ports_with_multiple_sub_ports)}
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code is None
@@ -58,7 +68,7 @@ def test_tuple_result(fixture_localhost):
 
 def test_tuple_result_mismatch(fixture_localhost):
     result = (1, 2)
-    function_data = {"output_ports": orm.List([{"name": "a"}, {"name": "b"}, {"name": "c"}])}
+    function_data = {"output_ports": orm.Dict(output_ports_with_multiple_sub_ports)}
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code == parser.exit_codes.ERROR_RESULT_OUTPUT_MISMATCH
@@ -66,7 +76,18 @@ def test_tuple_result_mismatch(fixture_localhost):
 
 def test_dict_result(fixture_localhost):
     result = {"a": 1, "b": 2, "c": 3}
-    function_data = {"output_ports": orm.List([{"name": "a"}, {"name": "b"}])}
+    function_data = {
+        "output_ports": orm.Dict(
+            {
+                "name": "outputs",
+                "identifier": "namespace",
+                "ports": [
+                    {"name": "a", "identifier": "any"},
+                    {"name": "b", "identifier": "any"},
+                ],
+            }
+        )
+    }
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code is None
@@ -77,7 +98,7 @@ def test_dict_result(fixture_localhost):
 
 def test_dict_result_missing(fixture_localhost):
     result = {"a": 1, "b": 2}
-    function_data = {"output_ports": orm.List([{"name": "a"}, {"name": "b"}, {"name": "c"}])}
+    function_data = {"output_ports": orm.Dict(output_ports_with_multiple_sub_ports)}
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code == parser.exit_codes.ERROR_MISSING_OUTPUT
@@ -85,7 +106,11 @@ def test_dict_result_missing(fixture_localhost):
 
 def test_dict_result_as_one_output(fixture_localhost):
     result = {"a": 1, "b": 2, "c": 3}
-    function_data = {"output_ports": orm.List([{"name": "result"}])}
+    function_data = {
+        "output_ports": orm.Dict(
+            {"name": "outputs", "identifier": "namespace", "ports": [{"name": "result", "identifier": "any"}]}
+        )
+    }
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code is None
@@ -95,7 +120,11 @@ def test_dict_result_as_one_output(fixture_localhost):
 
 def test_dict_result_only_show_one_output(fixture_localhost):
     result = {"a": 1, "b": 2}
-    function_data = {"output_ports": orm.List([{"name": "a"}])}
+    function_data = {
+        "output_ports": orm.Dict(
+            {"name": "outputs", "identifier": "namespace", "ports": [{"name": "a", "identifier": "any"}]}
+        )
+    }
     parser = create_parser(result, function_data)
     parser.parse()
     assert len(parser.outputs) == 1
@@ -106,14 +135,18 @@ def test_dict_result_only_show_one_output(fixture_localhost):
 
 def test_exit_code(fixture_localhost):
     result = {"a": 1, "exit_code": {"status": 0, "message": ""}}
-    function_data = {"output_ports": orm.List([{"name": "a"}])}
+    function_data = {
+        "output_ports": orm.Dict(
+            {"name": "outputs", "identifier": "namespace", "ports": [{"name": "a", "identifier": "any"}]}
+        )
+    }
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code is None
     assert parser.outputs["a"] == 1
     #
     result = {"exit_code": {"status": 1, "message": "error"}}
-    function_data = {"output_ports": orm.List([{"name": "a"}, {"name": "b"}, {"name": "c"}])}
+    function_data = {"output_ports": orm.Dict(output_ports_with_multiple_sub_ports)}
     parser = create_parser(result, function_data)
     exit_code = parser.parse()
     assert exit_code is not None
@@ -123,7 +156,11 @@ def test_exit_code(fixture_localhost):
 
 def test_no_output_file(fixture_localhost):
     result = {"a": 1, "b": 2, "c": 3}
-    function_data = {"output_ports": orm.List([{"name": "result"}])}
+    function_data = {
+        "output_ports": orm.Dict(
+            {"name": "outputs", "identifier": "namespace", "ports": [{"name": "result", "identifier": "any"}]}
+        )
+    }
     parser = create_parser(result, function_data, output_filename="not_results.pickle")
     exit_code = parser.parse()
     assert exit_code == parser.exit_codes.ERROR_READING_OUTPUT_FILE
@@ -142,7 +179,11 @@ def test_no_output_file(fixture_localhost):
 def test_run_script_error(error_type, status):
     error = {"error_type": error_type, "exception_message": "error", "traceback": "traceback"}
     result = {"a": 1, "exit_code": {"status": 0, "message": ""}}
-    function_data = {"output_ports": orm.List([{"name": "a"}])}
+    function_data = {
+        "output_ports": orm.Dict(
+            {"name": "outputs", "identifier": "namespace", "ports": [{"name": "a", "identifier": "any"}]}
+        )
+    }
     parser = create_parser(result, function_data, error=error)
     exit_code = parser.parse()
     assert exit_code is not None

--- a/tests/test_pyfunction.py
+++ b/tests/test_pyfunction.py
@@ -3,7 +3,7 @@ from aiida.engine import run_get_node
 from aiida_pythonjob import pyfunction
 
 
-def test_function_default_outputs():
+def test_function_default_outputs(fixture_localhost):
     """Test decorator."""
 
     @pyfunction()
@@ -14,6 +14,22 @@ def test_function_default_outputs():
 
     assert result.value == 3
     assert node.process_label == "add"
+
+
+def test_output_tuple():
+    @pyfunction(
+        outputs=[
+            {"name": "sum"},
+            {"name": "diff"},
+        ]
+    )
+    def add(x, y):
+        return x + y, x - y
+
+    result, node = run_get_node(add, x=1, y=2)
+
+    assert result["sum"].value == 3
+    assert result["diff"].value == -1
 
 
 def test_function_custom_outputs():
@@ -35,12 +51,25 @@ def test_function_custom_outputs():
     assert node.process_label == "add"
 
 
+def test_function_custom_inputs_outputs():
+    @pyfunction(
+        inputs=[{"name": "volumes", "identifier": "namespace"}, {"name": "energies", "identifier": "namespace"}],
+        outputs=[{"name": "volumes", "identifier": "namespace"}, {"name": "energies", "identifier": "namespace"}],
+    )
+    def plot_eos(volumes, energies):
+        return {"volumes": volumes, "energies": energies}
+
+    _, node = run_get_node(plot_eos, volumes={"s_1": 1, "s_2": 2, "s_3": 3}, energies={"s_1": 1, "s_2": 2, "s_3": 3})
+    assert node.inputs.function_inputs.volumes.s_1.value == 1
+    assert node.outputs.volumes.s_1.value == 1
+
+
 def test_importable_function():
     """Test importable function."""
     from ase.build import bulk
 
-    result, _ = run_get_node(pyfunction()(bulk), name="Si")
-    assert result.value.get_chemical_formula() == "Si2"
+    result, _ = run_get_node(pyfunction()(bulk), name="Si", cubic=True)
+    assert result.value.get_chemical_formula() == "Si8"
 
 
 def test_kwargs_inputs():
@@ -65,10 +94,7 @@ def test_namespace_output():
             {
                 "name": "add_multiply",
                 "identifier": "namespace",
-            },
-            {
-                "name": "add_multiply.add",
-                "identifier": "namespace",
+                "ports": [{"name": "add", "identifier": "namespace"}, "multiply"],
             },
             {"name": "minus"},
         ]
@@ -107,10 +133,7 @@ def test_override_outputs():
             {
                 "name": "add_multiply",
                 "identifier": "namespace",
-            },
-            {
-                "name": "add_multiply.add",
-                "identifier": "namespace",
+                "ports": [{"name": "add", "identifier": "namespace"}],
             },
             {"name": "minus"},
         ],
@@ -119,6 +142,34 @@ def test_override_outputs():
     assert result["add_multiply"]["add"]["order1"].value == 3
     assert result["add_multiply"]["add"]["order2"].value == 5
     assert result["add_multiply"]["multiply"].value == 2
+
+
+def test_function_execution_failed():
+    @pyfunction()
+    def add(x):
+        import math
+
+        return math.sqrt(x)
+
+    _, node = run_get_node(add, x=-2)
+    assert node.exit_status == 325
+
+
+def test_exit_code():
+    """Test function with exit code."""
+    from numpy import array
+
+    @pyfunction()
+    def add(x: array, y: array) -> array:
+        sum = x + y
+        if (sum < 0).any():
+            exit_code = {"status": 410, "message": "Some elements are negative"}
+            return {"sum": sum, "exit_code": exit_code}
+        return {"sum": sum}
+
+    result, node = run_get_node(add, x=array([1, 1]), y=array([1, -2]))
+    assert node.exit_status == 410
+    assert node.exit_message == "Some elements are negative"
 
 
 def test_aiida_node_as_inputs_outputs():
@@ -131,3 +182,73 @@ def test_aiida_node_as_inputs_outputs():
     result, node = run_get_node(add, x=orm.Int(1), y=orm.Int(2))
     assert set(result.keys()) == {"sum", "diff"}
     assert result["sum"].value == 3
+
+
+def test_missing_output():
+    @pyfunction(
+        outputs=[
+            {"name": "sum"},
+            {"name": "diff"},
+        ]
+    )
+    def add(x, y):
+        return {"sum": x + y}
+
+    result, node = run_get_node(add, x=1, y=2)
+
+    assert node.exit_status == 11
+
+
+def test_nested_inputs_outputs():
+    """Test function with nested inputs and outputs."""
+
+    @pyfunction(
+        inputs=[
+            {
+                "name": "input1",
+                "identifier": "namespace",
+                "ports": [
+                    {"name": "x1"},
+                    {"name": "y1"},
+                ],
+            },
+            {
+                "name": "input1",
+                "identifier": "namespace",
+                "ports": [
+                    {"name": "x2"},
+                    {"name": "y2"},
+                ],
+            },
+        ],
+        outputs=[
+            {
+                "name": "result1",
+                "identifier": "namespace",
+                "ports": [
+                    {"name": "sum1"},
+                    {"name": "diff1"},
+                ],
+            },
+            {
+                "name": "result2",
+                "identifier": "namespace",
+                "ports": [
+                    {"name": "sum2"},
+                    {"name": "diff2"},
+                ],
+            },
+        ],
+    )
+    def add(input1, input2):
+        return {
+            "result1": {"sum1": input1["x"] + input1["y"], "diff1": input1["x"] - input1["y"]},
+            "result2": {"sum2": input2["x"] + input2["y"], "diff2": input2["x"] - input2["y"]},
+        }
+
+    result, node = run_get_node(add, input1={"x": 1, "y": 2}, input2={"x": 1, "y": 3})
+
+    assert node.outputs.result1.sum1.value == 3
+    assert node.outputs.result1.diff1.value == -1
+    assert node.outputs.result2.sum2.value == 4
+    assert node.outputs.result2.diff2.value == -2

--- a/tests/test_pyfunction.py
+++ b/tests/test_pyfunction.py
@@ -103,7 +103,7 @@ def test_override_outputs():
         myfunc,
         x=1,
         y=2,
-        function_outputs=[
+        output_ports=[
             {
                 "name": "add_multiply",
                 "identifier": "namespace",

--- a/tests/test_pythonjob.py
+++ b/tests/test_pythonjob.py
@@ -8,7 +8,7 @@ from aiida.engine import run_get_node
 from aiida_pythonjob import PythonJob, prepare_pythonjob_inputs
 
 
-def test_validate_inputs():
+def test_validate_inputs(fixture_localhost):
     def add(x, y):
         return x + y
 
@@ -115,10 +115,7 @@ def test_namespace_output(fixture_localhost):
             {
                 "name": "add_multiply",
                 "identifier": "namespace",
-            },
-            {
-                "name": "add_multiply.add",
-                "identifier": "namespace",
+                "ports": [{"name": "add", "identifier": "namespace"}, "multiply"],
             },
             {"name": "minus"},
         ],

--- a/tests/test_pythonjob.py
+++ b/tests/test_pythonjob.py
@@ -49,7 +49,7 @@ def test_function_custom_outputs(fixture_localhost):
     inputs = prepare_pythonjob_inputs(
         add,
         function_inputs={"x": 1, "y": 2},
-        function_outputs=[
+        output_ports=[
             {"name": "sum"},
             {"name": "diff"},
         ],
@@ -69,7 +69,7 @@ def test_importable_function(fixture_localhost):
     inputs = prepare_pythonjob_inputs(
         add,
         function_inputs={"x": 1, "y": 2},
-        function_outputs=[
+        output_ports=[
             {"name": "sum"},
         ],
     )
@@ -90,7 +90,7 @@ def test_kwargs_inputs(fixture_localhost):
     inputs = prepare_pythonjob_inputs(
         add,
         function_inputs={"x": 1, "y": 2, "a": 3, "b": 4},
-        function_outputs=[
+        output_ports=[
             {"name": "sum"},
         ],
     )
@@ -111,7 +111,7 @@ def test_namespace_output(fixture_localhost):
     inputs = prepare_pythonjob_inputs(
         myfunc,
         function_inputs={"x": 1, "y": 2},
-        function_outputs=[
+        output_ports=[
             {
                 "name": "add_multiply",
                 "identifier": "namespace",
@@ -148,14 +148,14 @@ def test_parent_folder_remote(fixture_localhost):
     inputs1 = prepare_pythonjob_inputs(
         add,
         function_inputs={"x": 1, "y": 2},
-        function_outputs=[{"name": "sum"}],
+        output_ports=[{"name": "sum"}],
     )
     result1, node1 = run_get_node(PythonJob, inputs=inputs1)
 
     inputs2 = prepare_pythonjob_inputs(
         multiply,
         function_inputs={"x": 1, "y": 2},
-        function_outputs=[{"name": "product"}],
+        output_ports=[{"name": "product"}],
         parent_folder=result1["remote_folder"],
     )
     result2, node2 = run_get_node(PythonJob, inputs=inputs2)
@@ -181,7 +181,7 @@ def test_parent_folder_local(fixture_localhost):
         inputs2 = prepare_pythonjob_inputs(
             multiply,
             function_inputs={"x": 1, "y": 2},
-            function_outputs=[{"name": "product"}],
+            output_ports=[{"name": "product"}],
             parent_folder=parent_folder,
         )
         result2, node2 = run_get_node(PythonJob, inputs=inputs2)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 from aiida_pythonjob.utils import build_function_data
 
 
-def test_build_function_data():
+def test_build_function_data(aiida_profile):
     """Test the build_function_data function behavior."""
 
     with pytest.raises(TypeError, match="Provided object is not a callable function or class."):


### PR DESCRIPTION

- rename `function_outputs` to `output_ports`
- add support for `input_ports`
- `PyFunction` and `PythonJob` share the helper parser function.
