### PR TITLE
Remove PickleData

### DIFF
--- a/docs/gallery/autogen/common_concepts.py
+++ b/docs/gallery/autogen/common_concepts.py
@@ -203,8 +203,7 @@ print("nested product:", result["nested"]["product"])
 #    object's type (e.g., ``ase.atoms.Atoms``).
 # 2. If no specific serializer is found, it attempts to store the data using
 #    ``JsonableData``.
-# 3. If the data is not JSON-serializable, it will be pickled using
-#    ``PickledData`` **only if** ``use_pickle=True`` is set.
+# 3. If the data is not JSON-serializable, it will raise an error.
 #
 # Registering a custom serializer
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -226,8 +225,7 @@ print("nested product:", result["nested"]["product"])
 # that returns a simple Python type. For example, an ``Int`` node has a ``.value``
 # attribute that returns a standard Python integer. Similarly, from aiida-core v2.7.0
 # onwards, the ``Dict`` and ``List`` nodes also have ``.value`` attributes that return
-# standard Python dictionaries and lists. The ``PickledData`` and ``JsonableData`` nodes also have a ``.value``
-# attribute that returns the unpickled Python object.
+# standard Python dictionaries and lists.
 #
 # However, if the input AiiDA node does not have a ``.value`` attribute, you need to
 # register a deserializer for it. This ensures the node can be converted into a
@@ -264,19 +262,5 @@ print("nested product:", result["nested"]["product"])
 #        "deserializers": {
 #            "aiida.orm.nodes.data.structure.StructureData": "aiida_pythonjob.data.deserializer.structure_data_to_pymatgen"  # noqa: E501
 #        },
-#        "use_pickle": false
 #    }
-#
-# Using pickle for non-JSON Data
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# For one-off cases involving non-JSON-serializable data, you can enable
-# pickle serialization by passing ``use_pickle=True``.
-#
-# .. code-block:: python
-#
-#     inputs = prepare_pyfunction_inputs(
-#         my_function,
-#         function_inputs={"data": MyCustomObject(1)},
-#         use_pickle=True
-#     )
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ requires-python = ">=3.9"
 dependencies = [
     "aiida-core>=2.3,<3",
     "ase",
-    "cloudpickle",
     "node-graph>=0.3.0",
 ]
 
@@ -53,7 +52,6 @@ Source = "https://github.com/aiidateam/aiida-pythonjob"
 
 [project.entry-points."aiida.data"]
 "pythonjob.jsonable_data" = "aiida_pythonjob.data.jsonable_data:JsonableData"
-"pythonjob.pickled_data" = "aiida_pythonjob.data.pickled_data:PickledData"
 "pythonjob.ase.atoms.Atoms" = "aiida_pythonjob.data.atoms:AtomsData"
 "pythonjob.builtins.NoneType" = "aiida_pythonjob.data.common_data:NoneData"
 "pythonjob.builtins.int" = "aiida.orm.nodes.data.int:Int"

--- a/src/aiida_pythonjob/__init__.py
+++ b/src/aiida_pythonjob/__init__.py
@@ -10,7 +10,6 @@ from .launch import prepare_pyfunction_inputs, prepare_pythonjob_inputs
 from .parsers import PythonJobParser
 
 __all__ = (
-    "PickledData",
     "PyFunction",
     "PythonJob",
     "PythonJobParser",

--- a/src/aiida_pythonjob/calculations/common.py
+++ b/src/aiida_pythonjob/calculations/common.py
@@ -10,7 +10,6 @@ from aiida_pythonjob.data.deserializer import deserialize_to_raw_python_data
 
 # Attribute keys stored on ProcessNode.base.attributes
 ATTR_OUTPUTS_SPEC = "outputs_spec"
-ATTR_USE_PICKLE = "use_pickle"
 ATTR_SERIALIZERS = "serializers"
 ATTR_DESERIALIZERS = "deserializers"
 
@@ -27,12 +26,6 @@ def add_common_function_io(spec) -> None:
         valid_type=dict,
         required=False,
         help="Specification for the outputs.",
-    )
-    spec.input(
-        "metadata.use_pickle",
-        valid_type=bool,
-        required=False,
-        help="Allow pickling of function inputs and outputs.",
     )
     spec.input("process_label", valid_type=Str, serializer=to_aiida_type, required=False)
 
@@ -115,7 +108,6 @@ class FunctionProcessMixin:
     def _setup_metadata(self, metadata: dict) -> None:  # type: ignore[override]
         """Store common metadata on the ProcessNode and forward the rest."""
         self.node.base.attributes.set(ATTR_OUTPUTS_SPEC, metadata.pop("outputs_spec", {}))
-        self.node.base.attributes.set(ATTR_USE_PICKLE, metadata.pop("use_pickle", False))
         self.node.base.attributes.set(ATTR_SERIALIZERS, metadata.pop("serializers", {}))
         self.node.base.attributes.set(ATTR_DESERIALIZERS, metadata.pop("deserializers", {}))
         super()._setup_metadata(metadata)

--- a/src/aiida_pythonjob/calculations/pyfunction.py
+++ b/src/aiida_pythonjob/calculations/pyfunction.py
@@ -17,7 +17,6 @@ from aiida_pythonjob.calculations.common import (
     ATTR_DESERIALIZERS,
     ATTR_OUTPUTS_SPEC,
     ATTR_SERIALIZERS,
-    ATTR_USE_PICKLE,
     FunctionProcessMixin,
     add_common_function_io,
 )
@@ -115,7 +114,6 @@ class PyFunction(FunctionProcessMixin, Process):
 
         # Parse & attach outputs
         outputs_spec = SocketSpec.from_dict(self.node.base.attributes.get(ATTR_OUTPUTS_SPEC) or {})
-        use_pickle = self.node.base.attributes.get(ATTR_USE_PICKLE, False)
         serializers = self.node.base.attributes.get(ATTR_SERIALIZERS, {})
         outputs, exit_code = parse_outputs(
             results,
@@ -123,7 +121,6 @@ class PyFunction(FunctionProcessMixin, Process):
             exit_codes=self.exit_codes,
             logger=self.logger,
             serializers=serializers,
-            use_pickle=use_pickle,
         )
         if exit_code:
             return exit_code

--- a/src/aiida_pythonjob/decorator.py
+++ b/src/aiida_pythonjob/decorator.py
@@ -22,7 +22,6 @@ LOGGER = logging.getLogger(__name__)
 def pyfunction(
     inputs: t.Optional[SocketSpec | List[str]] = None,
     outputs: t.Optional[t.List[SocketSpec | List[str]]] = None,
-    use_pickle: bool | None = None,
 ) -> t.Callable[[FunctionType], FunctionType]:
     """The base function decorator to create a FunctionProcess out of a normal python function.
 
@@ -83,7 +82,6 @@ def pyfunction(
                 deserializers=deserializers,
                 serializers=serializers,
                 register_pickle_by_value=register_pickle_by_value,
-                use_pickle=use_pickle,
             )
 
             process = PyFunction(inputs=process_inputs, runner=runner)

--- a/src/aiida_pythonjob/launch.py
+++ b/src/aiida_pythonjob/launch.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import inspect
 import os
-from typing import Any, Callable, Dict, Optional, Union
+import types
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 from aiida import orm
 from node_graph.node_spec import BaseHandle
@@ -14,16 +15,158 @@ from aiida_pythonjob.data.serializer import all_serializers
 from .utils import build_function_data, get_or_create_code, serialize_ports
 
 
-def validate_inputs(func, inputs: dict):
-    sig = inspect.signature(func)
+def _unwrap_callable(func: Any) -> Callable[..., Any] | None:
+    """
+    Return a plain Python function from several supported wrappers.
+    Returns None if func is None. Raises for unsupported types.
+    """
+    if func is None:
+        return None
+    if isinstance(func, BaseHandle) and hasattr(func, "_func"):
+        return func._func
+    if getattr(func, "is_process_function", False):
+        # aiida process_function wrapper (e.g., calcfunction/workfunction)
+        return func.func
+    if inspect.isfunction(func):
+        return func
+    if isinstance(func, types.BuiltinFunctionType):
+        raise NotImplementedError("Built-in functions are not supported yet.")
+    raise ValueError(f"Invalid function type: {type(func)!r}")
 
+
+def _validate_inputs_against_signature(func: Callable[..., Any], inputs: dict) -> None:
+    """Raise ValueError if inputs do not bind to func's signature."""
+    sig = inspect.signature(func)
     try:
-        # Bind the provided inputs to the function's signature
         sig.bind(**inputs)
     except TypeError as e:
-        return False, str(e)
+        raise ValueError(f"Invalid function inputs: {e}") from e
 
-    return True, "Inputs are valid."
+
+def _merge_registry(overrides: dict | None, base: dict) -> dict:
+    """Shallow-merge (user overrides win)."""
+    return {**base, **(overrides or {})}
+
+
+def _normalize_upload_files(
+    upload_files: Dict[str, Union[str, orm.SinglefileData, orm.FolderData]] | None,
+) -> Dict[str, Union[orm.SinglefileData, orm.FolderData]]:
+    """
+    Convert string paths to AiiDA SinglefileData/FolderData and sanitize keys.
+    """
+    result: Dict[str, Union[orm.SinglefileData, orm.FolderData]] = {}
+    if not upload_files:
+        return result
+
+    for key, source in upload_files.items():
+        # Only alphanumeric + underscore in keys; also make dots explicit
+        new_key = key.replace(".", "_dot_")
+
+        if isinstance(source, str):
+            if os.path.isfile(source):
+                result[new_key] = orm.SinglefileData(file=source)
+            elif os.path.isdir(source):
+                result[new_key] = orm.FolderData(tree=source)
+            else:
+                raise ValueError(f"Invalid upload file path: {source!r}")
+        elif isinstance(source, (orm.SinglefileData, orm.FolderData)):
+            result[new_key] = source
+        else:
+            raise ValueError(f"Invalid upload file type: {type(source)}, value={source!r}")
+
+    return result
+
+
+def _maybe_build_function_data(func: Callable[..., Any] | None, *, register_pickle_by_value: bool) -> dict | None:
+    """Build function_data if we have a Python function; else return None."""
+    if func is None:
+        return None
+    return build_function_data(func, register_pickle_by_value=register_pickle_by_value)
+
+
+def _prepare_common(
+    *,
+    function: Optional[Callable[..., Any]],
+    function_data: Optional[dict],
+    function_inputs: Optional[Dict[str, Any]],
+    inputs_spec: Optional[type],
+    outputs_spec: Optional[type],
+    serializers: Optional[dict],
+    deserializers: Optional[dict],
+    register_pickle_by_value: bool,
+    validate_signature: bool,
+) -> Tuple[dict, dict, dict, dict]:
+    """
+    Shared logic used by both PyFunction and PythonJob preparations.
+
+    Returns:
+        (prepared_inputs, outputs_spec_dict, merged_serializers, merged_deserializers)
+        where prepared_inputs = {"function_data": ..., "function_inputs": ..., "metadata": {...}}
+    """
+    # Unwrap and normalize the function
+    fn = _unwrap_callable(function)
+
+    # Guard: either function or function_data must be present, but not both
+    if fn is None and function_data is None:
+        raise ValueError("Either `function` or `function_data` must be provided.")
+    if fn is not None and function_data is not None:
+        raise ValueError("Only one of `function` or `function_data` should be provided.")
+
+    # If we have a Python function, build function_data from source/pickle
+    if fn is not None:
+        function_data = _maybe_build_function_data(fn, register_pickle_by_value=register_pickle_by_value)
+
+    # Infer I/O specs
+    in_spec, out_spec = infer_specs_from_callable(fn, inputs=inputs_spec, outputs=outputs_spec)
+
+    # Merge serializer/deserializer registries (user wins)
+    merged_serializers = _merge_registry(serializers, all_serializers)
+    merged_deserializers = _merge_registry(deserializers, all_deserializers)
+
+    # Serialize inputs according to (possibly nested) input schema
+    py_inputs = function_inputs or {}
+    serialized_inputs = serialize_ports(
+        python_data=py_inputs,
+        port_schema=in_spec,
+        serializers=merged_serializers,
+    )
+
+    # Optional: validate against fn signature (bind) using the PROVIDED keys.
+    # Binding cares about names/arity, not the exact serialized types.
+    if validate_signature and fn is not None:
+        _validate_inputs_against_signature(fn, serialized_inputs)
+
+    metadata = {
+        "outputs_spec": out_spec.to_dict(),
+        "serializers": merged_serializers,
+        "deserializers": merged_deserializers,
+    }
+
+    prepared = {
+        "function_data": function_data,
+        "function_inputs": serialized_inputs,
+        "metadata": metadata,
+    }
+    return prepared, metadata["outputs_spec"], merged_serializers, merged_deserializers
+
+
+def create_inputs(func: Callable[..., Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
+    """
+    Create the input dictionary for calling a Python function by name-binding.
+    Positional args are mapped to positional parameters; **kwargs are merged on top.
+    Variable positional parameters (*args) are not supported.
+    """
+    inputs = dict(kwargs or {})
+    arguments = list(args)
+    for name, param in inspect.signature(func).parameters.items():
+        if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD):
+            try:
+                inputs[name] = arguments.pop(0)
+            except IndexError:
+                pass
+        elif param.kind is param.VAR_POSITIONAL:
+            raise NotImplementedError("Variable positional arguments (*args) are not supported.")
+    return inputs
 
 
 def prepare_pythonjob_inputs(
@@ -35,89 +178,46 @@ def prepare_pythonjob_inputs(
     command_info: Optional[Dict[str, str]] = None,
     computer: Union[str, orm.Computer] = "localhost",
     metadata: Optional[Dict[str, Any]] = None,
-    upload_files: Dict[str, str] = {},
+    upload_files: Optional[Dict[str, Union[str, orm.SinglefileData, orm.FolderData]]] = None,
     process_label: Optional[str] = None,
     function_data: dict | None = None,
     deserializers: dict | None = None,
     serializers: dict | None = None,
     register_pickle_by_value: bool = False,
-    use_pickle: bool | None = None,
     **kwargs: Any,
 ) -> Dict[str, Any]:
-    """Prepare the inputs for PythonJob"""
-
-    if function is None and function_data is None:
-        raise ValueError("Either function or function_data must be provided")
-    if function is not None and function_data is not None:
-        raise ValueError("Only one of function or function_data should be provided")
-    if isinstance(function, BaseHandle):
-        function = function._func
-    # if function is a function, inspect it and get the source code
-    if function is not None and inspect.isfunction(function):
-        function_data = build_function_data(function, register_pickle_by_value=register_pickle_by_value)
-    new_upload_files = {}
-    # change the string in the upload files to SingleFileData, or FolderData
-    for key, source in upload_files.items():
-        # only alphanumeric and underscores are allowed in the key
-        # replace all "." with "_dot_"
-        new_key = key.replace(".", "_dot_")
-        if isinstance(source, str):
-            if os.path.isfile(source):
-                new_upload_files[new_key] = orm.SinglefileData(file=source)
-            elif os.path.isdir(source):
-                new_upload_files[new_key] = orm.FolderData(tree=source)
-            else:
-                raise ValueError(f"Invalid upload file path: {source}")
-        elif isinstance(source, (orm.SinglefileData, orm.FolderData)):
-            new_upload_files[new_key] = source
-        else:
-            raise ValueError(f"Invalid upload file type: {type(source)}, {source}")
-    if code is None:
-        command_info = command_info or {}
-        code = get_or_create_code(computer=computer, **command_info)
-    in_spec, out_spec = infer_specs_from_callable(function, inputs=inputs_spec, outputs=outputs_spec)
-    metadata = metadata or {}
-    metadata["outputs_spec"] = out_spec.to_dict()
-    # serialize kwargs against the (nested) input schema
-    serializers = {**all_serializers, **(serializers or {})}
-    deserializers = {**all_deserializers, **(deserializers or {})}
-    function_inputs = function_inputs or {}
-    function_inputs = serialize_ports(
-        python_data=function_inputs, port_schema=in_spec, serializers=serializers, use_pickle=use_pickle
+    """
+    Prepare the inputs for a PythonJob (runner that needs a Code and optional upload_files).
+    """
+    prepared, _, _, _ = _prepare_common(
+        function=function,
+        function_data=function_data,
+        function_inputs=function_inputs,
+        inputs_spec=inputs_spec,
+        outputs_spec=outputs_spec,
+        serializers=serializers,
+        deserializers=deserializers,
+        register_pickle_by_value=register_pickle_by_value,
+        validate_signature=(function is not None),  # only when we actually got a function
     )
-    if function is not None:
-        valid, msg = validate_inputs(function, function_inputs)
-        if not valid:
-            raise ValueError(f"Invalid function inputs: {msg}")
-    metadata["serializers"] = serializers
-    metadata["deserializers"] = deserializers
-    inputs = {
-        "function_data": function_data,
+
+    # Files & Code specifics
+    new_upload_files = _normalize_upload_files(upload_files)
+    if code is None:
+        code = get_or_create_code(computer=computer, **(command_info or {}))
+
+    # Merge external metadata if provided
+    md = {**prepared["metadata"], **(metadata or {})}
+    prepared["metadata"] = md
+
+    inputs: Dict[str, Any] = {
+        **prepared,
         "code": code,
-        "function_inputs": function_inputs,
         "upload_files": new_upload_files,
-        "metadata": metadata,
         **kwargs,
     }
     if process_label:
         inputs["process_label"] = process_label
-    return inputs
-
-
-def create_inputs(func, *args: Any, **kwargs: Any) -> dict[str, Any]:
-    """Create the input dictionary for the ``FunctionProcess``."""
-    # The complete input dictionary consists of the keyword arguments...
-    inputs = dict(kwargs or {})
-    arguments = list(args)
-    for name, parameter in inspect.signature(func).parameters.items():
-        if parameter.kind in [parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD]:
-            try:
-                inputs[name] = arguments.pop(0)
-            except IndexError:
-                pass
-        elif parameter.kind is parameter.VAR_POSITIONAL:
-            raise NotImplementedError("Variable positional arguments are not yet supported")
-
     return inputs
 
 
@@ -132,45 +232,29 @@ def prepare_pyfunction_inputs(
     deserializers: dict | None = None,
     serializers: dict | None = None,
     register_pickle_by_value: bool = False,
-    use_pickle: bool | None = None,
     **kwargs: Any,
 ) -> Dict[str, Any]:
-    """Prepare the inputs for PyFunction."""
-    import types
-
-    if function is None and function_data is None:
-        raise ValueError("Either function or function_data must be provided")
-    if function is not None and function_data is not None:
-        raise ValueError("Only one of function or function_data should be provided")
-    if isinstance(function, BaseHandle):
-        function = function._func
-    elif hasattr(function, "is_process_function") and function.is_process_function:
-        function = function.func
-    # if function is a function, inspect it and get the source code
-    if function is not None:
-        if inspect.isfunction(function):
-            function_data = build_function_data(function, register_pickle_by_value=register_pickle_by_value)
-        elif isinstance(function, types.BuiltinFunctionType):
-            raise NotImplementedError("Built-in functions are not supported yet")
-        else:
-            raise ValueError("Invalid function type")
-    # spec
-    in_spec, out_spec = infer_specs_from_callable(function, inputs=inputs_spec, outputs=outputs_spec)
-    metadata = metadata or {}
-    metadata["outputs_spec"] = out_spec.to_dict()
-    # serialize the kwargs into AiiDA Data
-    serializers = {**all_serializers, **(serializers or {})}
-    deserializers = {**all_deserializers, **(deserializers or {})}
-    function_inputs = function_inputs or {}
-    function_inputs = serialize_ports(
-        python_data=function_inputs, port_schema=in_spec, serializers=serializers, use_pickle=use_pickle
+    """
+    Prepare the inputs for a local PyFunction (no Code/upload_files).
+    """
+    prepared, _, _, _ = _prepare_common(
+        function=function,
+        function_data=function_data,
+        function_inputs=function_inputs,
+        inputs_spec=inputs_spec,
+        outputs_spec=outputs_spec,
+        serializers=serializers,
+        deserializers=deserializers,
+        register_pickle_by_value=register_pickle_by_value,
+        validate_signature=False,  # leave binding checks to the engine if desired
     )
-    metadata["serializers"] = serializers
-    metadata["deserializers"] = deserializers
-    inputs = {
-        "function_data": function_data,
-        "function_inputs": function_inputs,
-        "metadata": metadata,
+
+    # Merge external metadata if provided
+    md = {**prepared["metadata"], **(metadata or {})}
+    prepared["metadata"] = md
+
+    inputs: Dict[str, Any] = {
+        **prepared,
         **kwargs,
     }
     if process_label:

--- a/src/aiida_pythonjob/parsers/pythonjob.py
+++ b/src/aiida_pythonjob/parsers/pythonjob.py
@@ -25,7 +25,6 @@ class PythonJobParser(Parser):
 
         # Read outputs SocketSpec
         spec_dict = self.node.base.attributes.get("outputs_spec", {})
-        use_pickle = self.node.base.attributes.get("use_pickle", False)
         self.outputs_spec = SocketSpec.from_dict(spec_dict)
 
         # load custom serializers
@@ -65,7 +64,6 @@ class PythonJobParser(Parser):
                     exit_codes=self.exit_codes,
                     logger=self.logger,
                     serializers=self.serializers,
-                    use_pickle=use_pickle,
                 )
                 if exit_code:
                     return exit_code

--- a/src/aiida_pythonjob/parsers/utils.py
+++ b/src/aiida_pythonjob/parsers/utils.py
@@ -35,7 +35,6 @@ def parse_outputs(
     exit_codes,
     logger,
     serializers: Optional[Dict[str, str]] = None,
-    use_pickle: bool = False,
 ) -> Tuple[Optional[Dict[str, Any]], Optional[ExitCode]]:
     """Validate & convert *results* according to *output_spec*.
 
@@ -60,7 +59,7 @@ def parse_outputs(
         for i, name in enumerate(names):
             child_spec = fields[name]
             val = results[i]
-            outs[name] = serialize_ports(val, child_spec, serializers=serializers, use_pickle=use_pickle)
+            outs[name] = serialize_ports(val, child_spec, serializers=serializers)
         return outs, None
 
     # dict
@@ -85,21 +84,19 @@ def parse_outputs(
             ((only_name, only_spec),) = fields.items()
             # if user used the same key as port name, use that value;
             if only_name in results:
-                outs[only_name] = serialize_ports(
-                    results.pop(only_name), only_spec, serializers=serializers, use_pickle=use_pickle
-                )
+                outs[only_name] = serialize_ports(results.pop(only_name), only_spec, serializers=serializers)
                 if results:
                     logger.warning(f"Found extra results that are not included in the output: {list(results.keys())}")
             else:
                 # else treat the entire dict as the value for that single port.
-                outs[only_name] = serialize_ports(results, only_spec, serializers=serializers, use_pickle=use_pickle)
+                outs[only_name] = serialize_ports(results, only_spec, serializers=serializers)
             return outs, None
 
         # fixed fields
         for name, child_spec in fields.items():
             if name in remaining:
                 value = remaining.pop(name)
-                outs[name] = serialize_ports(value, child_spec, serializers=serializers, use_pickle=use_pickle)
+                outs[name] = serialize_ports(value, child_spec, serializers=serializers)
             else:
                 # If the field is explicitly required -> invalid output
                 required = getattr(child_spec.meta, "required", None)
@@ -115,7 +112,6 @@ def parse_outputs(
                     value,
                     item_spec or SocketSpec(identifier="node_graph.any"),
                     serializers=serializers,
-                    use_pickle=use_pickle,
                 )
             return outs, None
         # not dynamic -> leftovers are unexpected (warn but continue)
@@ -126,6 +122,6 @@ def parse_outputs(
     # single fixed output + non-dict/tuple scalar
     if len(fields) == 1 and not is_dyn:
         ((only_name, only_spec),) = fields.items()
-        return {only_name: serialize_ports(results, only_spec, serializers=serializers, use_pickle=use_pickle)}, None
+        return {only_name: serialize_ports(results, only_spec, serializers=serializers)}, None
 
     return None, exit_codes.ERROR_RESULT_OUTPUT_MISMATCH

--- a/src/aiida_pythonjob/utils.py
+++ b/src/aiida_pythonjob/utils.py
@@ -283,7 +283,6 @@ def serialize_ports(
     python_data: Any,
     port_schema: SocketSpec | Dict[str, Any],
     serializers: Optional[Dict[str, str]] = None,
-    use_pickle: bool | None = None,
 ) -> Any:
     """Serialize raw Python data to AiiDA Data following a SocketSpec schema.
 
@@ -309,21 +308,21 @@ def serialize_ports(
             if key in fields:
                 child_spec = fields[key]
                 if child_spec.is_namespace():
-                    out[key] = serialize_ports(value, child_spec, serializers=serializers, use_pickle=use_pickle)
+                    out[key] = serialize_ports(value, child_spec, serializers=serializers)
                 else:
-                    out[key] = general_serializer(value, serializers=serializers, store=False, use_pickle=use_pickle)
+                    out[key] = general_serializer(value, serializers=serializers, store=False)
             elif (is_dyn and item_spec is not None) or allow_extra:
                 schema = item_spec if (is_dyn and item_spec is not None) else catch_schema
                 if schema.is_namespace():
-                    out[key] = serialize_ports(value, schema, serializers=serializers, use_pickle=use_pickle)
+                    out[key] = serialize_ports(value, schema, serializers=serializers)
                 else:
-                    out[key] = general_serializer(value, serializers=serializers, store=False, use_pickle=use_pickle)
+                    out[key] = general_serializer(value, serializers=serializers, store=False)
             else:
                 raise ValueError(f"Unexpected key '{key}' for namespace '{name}' (not dynamic).")
         return out
 
     # Leaf
-    return general_serializer(python_data, serializers=serializers, store=False, use_pickle=use_pickle)
+    return general_serializer(python_data, serializers=serializers, store=False)
 
 
 def deserialize_ports(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -30,22 +30,14 @@ def test_typing():
 
 def test_python_job():
     """Test a simple python node."""
-    from aiida_pythonjob.config import config
-    from aiida_pythonjob.data.pickled_data import PickledData
     from aiida_pythonjob.data.serializer import serialize_to_aiida_nodes
 
     inputs = {"a": 1, "b": 2.0, "c": set()}
     with pytest.raises(
         ValueError,
-        match="Cannot serialize type=set. No suitable method found",
+        match="Cannot serialize the provided object.",
     ):
-        new_inputs = serialize_to_aiida_nodes(inputs, serializers=all_serializers)
-    # Allow pickling
-    config["use_pickle"] = True
-    new_inputs = serialize_to_aiida_nodes(inputs, serializers=all_serializers)
-    assert isinstance(new_inputs["a"], aiida.orm.Int)
-    assert isinstance(new_inputs["b"], aiida.orm.Float)
-    assert isinstance(new_inputs["c"], PickledData)
+        serialize_to_aiida_nodes(inputs, serializers=all_serializers)
 
 
 def test_atoms_data():

--- a/tests/test_pythonjob.py
+++ b/tests/test_pythonjob.py
@@ -14,11 +14,11 @@ def test_validate_inputs(fixture_localhost):
     def add(x, y):
         return x + y
 
-    with pytest.raises(ValueError, match="Either function or function_data must be provided"):
+    with pytest.raises(ValueError, match="Either `function` or `function_data` must be provided."):
         prepare_pythonjob_inputs(
             function_inputs={"x": 1, "y": 2},
         )
-    with pytest.raises(ValueError, match="Only one of function or function_data should be provided"):
+    with pytest.raises(ValueError, match="Only one of `function` or `function_data` should be provided."):
         prepare_pythonjob_inputs(
             function=add,
             function_data={"module_path": "math", "name": "sqrt", "is_pickle": False},

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -58,20 +58,3 @@ def test_serialize_json():
 
     serialized_data = general_serializer(data, serializers=all_serializers)
     assert isinstance(serialized_data, JsonableData)
-
-
-def test_serialize_pickle():
-    from aiida_pythonjob.config import config
-    from aiida_pythonjob.data.pickled_data import PickledData
-    from aiida_pythonjob.data.serializer import general_serializer
-
-    data = NonJsonableData("a", 1)
-    config["use_pickle"] = False
-    with pytest.raises(
-        ValueError,
-        match="Cannot serialize type=NonJsonableData. No suitable method found",
-    ):
-        general_serializer(data, serializers=all_serializers)
-    config["use_pickle"] = True
-    serialized_data = general_serializer(data, serializers=all_serializers)
-    assert isinstance(serialized_data, PickledData)


### PR DESCRIPTION
This PR drops support for persisting arbitrary Python objects via `PickledData`.

Serialization now follows a strict path:

1. Look up a registered `aiida.data` entry point for the object’s type (e.g. `ase.atoms.Atoms`).
2. Otherwise, fall back to `JsonableData`, which requires `to_dict`/`as_dict` and `from_dict`/`fromdict`.

For submitting Python functions (which are defined on-the-fly): we still pickle the callable **transiently** to shuttle it to the AiiDA process, but this payload is **not stored as an AiiDA node**. It lives only in the runtime checkpoint and is **deleted when the process finishes**.

So, persistent `PickledData` support has been removed.