### PR TITLE
Test aiida pre-release v2.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 keywords = ["aiida", "plugin"]
 requires-python = ">=3.10"
 dependencies = [
-    "aiida-core>=2.7.1,<3",
+    "aiida-core==2.8.0rc2",
     "ase",
     "node-graph~=0.6.1",
 ]


### PR DESCRIPTION
We need to actually not remove here but make its usage dependent on aiida-core version, since it is still needed for older versions.