### PR TITLE
Release v0.4.9

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -2,7 +2,7 @@ name: tests
 
 on:
   push:
-    branches: [main]
+    branches: ['main', 'support/v*']
   pull_request:
 
 jobs:

--- a/src/aiida_pythonjob/__init__.py
+++ b/src/aiida_pythonjob/__init__.py
@@ -1,6 +1,6 @@
 """AiiDA plugin that run Python function on remote computers."""
 
-__version__ = "0.4.8"
+__version__ = "0.4.9"
 
 from node_graph import socket_spec as spec
 

--- a/src/aiida_pythonjob/decorator.py
+++ b/src/aiida_pythonjob/decorator.py
@@ -20,7 +20,7 @@ from aiida_pythonjob.launch import create_inputs, prepare_pyfunction_inputs
 LOGGER = logging.getLogger(__name__)
 
 _AIIDA_VERSION = parse_version(aiida.__version__)
-_NEEDS_RECURSION_LIMIT_WORKAROUND = _AIIDA_VERSION < parse_version("2.8.0")
+_NEEDS_RECURSION_LIMIT_WORKAROUND = _AIIDA_VERSION < parse_version("2.8.0rc0")
 
 if _NEEDS_RECURSION_LIMIT_WORKAROUND:
     from aiida.engine.processes.functions import get_stack_size

--- a/src/aiida_pythonjob/decorator.py
+++ b/src/aiida_pythonjob/decorator.py
@@ -7,15 +7,23 @@ import sys
 import typing as t
 from typing import List
 
-from aiida.engine.processes.functions import FunctionType, get_stack_size
+import aiida
+from aiida.engine.processes.functions import FunctionType
 from aiida.manage import get_manager
 from aiida.orm import ProcessNode
 from node_graph.socket_spec import SocketSpec
+from packaging.version import parse as parse_version
 
 from aiida_pythonjob.calculations.pyfunction import PyFunction
 from aiida_pythonjob.launch import create_inputs, prepare_pyfunction_inputs
 
 LOGGER = logging.getLogger(__name__)
+
+_AIIDA_VERSION = parse_version(aiida.__version__)
+_NEEDS_RECURSION_LIMIT_WORKAROUND = _AIIDA_VERSION < parse_version("2.8.0")
+
+if _NEEDS_RECURSION_LIMIT_WORKAROUND:
+    from aiida.engine.processes.functions import get_stack_size
 
 
 # The following code is modified from the aiida-core.engine.processes.functions module
@@ -42,25 +50,26 @@ def pyfunction(
             :param kwargs: input keyword arguments to construct the FunctionProcess
             :return: tuple of the outputs of the process and the process node
             """
-            frame_delta = 1000
-            frame_count = get_stack_size()
-            stack_limit = sys.getrecursionlimit()
-            LOGGER.info("Executing process function, current stack status: %d frames of %d", frame_count, stack_limit)
-
-            # If the current frame count is more than 80% of the stack limit, or comes within 200 frames, increase the
-            # stack limit by ``frame_delta``.
-            if frame_count > min(0.8 * stack_limit, stack_limit - 200):
-                LOGGER.warning(
-                    "Current stack contains %d frames which is close to the limit of %d. Increasing the limit by %d",
-                    frame_count,
-                    stack_limit,
-                    frame_delta,
+            if _NEEDS_RECURSION_LIMIT_WORKAROUND:
+                frame_delta = 1000
+                frame_count = get_stack_size()
+                stack_limit = sys.getrecursionlimit()
+                LOGGER.info(
+                    "Executing process function, current stack status: %d frames of %d", frame_count, stack_limit
                 )
-                sys.setrecursionlimit(stack_limit + frame_delta)
+
+                if frame_count > min(0.8 * stack_limit, stack_limit - 200):
+                    LOGGER.warning(
+                        "Current stack contains %d frames which is close to the limit of %d. Increasing the limit by %d",
+                        frame_count,
+                        stack_limit,
+                        frame_delta,
+                    )
+                    sys.setrecursionlimit(stack_limit + frame_delta)
 
             manager = get_manager()
             runner = manager.get_runner()
-            # # Remove all the known inputs from the kwargs
+            # Remove all the known inputs from the kwargs
             outputs_spec = kwargs.pop("outputs_spec", None) or outputs
             inputs_spec = kwargs.pop("inputs_spec", None) or inputs
             metadata = kwargs.pop("metadata", None)


### PR DESCRIPTION
To also support aiida-core v2.8.0rc0 with py3.9 I add the fixes we just recently added with release 0.5.2 also to 0.4.* since py3.9 was dropped with 0.5.*.

Tested CI with aiida-core v2.8.0rc0 in PR #76 